### PR TITLE
docs: add instructions to install zbarimg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,16 @@
+PLATFORM := $(shell uname)
 
 # a phony dependency that can be used as a dependency to force builds
 FORCE:
 
 install:
+ifeq ($(PLATFORM),Darwin)
+	brew install zbar
+else ifeq ($(PLATFORM),Linux)
 	apt install zbar-tools
+else
+	@echo "zbar cannot be installed on unknown platform: $(PLATFORM)"
+endif
 
 build: FORCE
 	yarn install

--- a/README.md
+++ b/README.md
@@ -4,19 +4,30 @@ This web server component provides a web interface to a scanner
 
 ## Install Requisite Software
 
-```
+```sh
+# install application packages
 yarn install
+
+# install external tools (macOS)
+if [ "$(uname)" = "Darwin" ]; then
+  brew install zbar
+fi
+
+# install external tools (linux)
+if [ "$(uname)" = "Linux" ]; then
+  sudo apt-get install -y zbar-tools
+fi
 ```
 
 ## Run Tests
 
-```
+```sh
 yarn test
 ```
 
 ## Start the Server
 
-```
+```sh
 yarn start
 ```
 
@@ -24,7 +35,8 @@ yarn start
 
 This scanner module provides the following API:
 
-* `GET /scan/status` returns status information:
+- `GET /scan/status` returns status information:
+
   ```
   {"batches": [
       {
@@ -35,21 +47,22 @@ This scanner module provides the following API:
       }
    ]
   }
-  ```		 
+  ```
 
-* `POST /scan/configure` configures the scanner with an `election.json` as the body
+- `POST /scan/configure` configures the scanner with an `election.json` as the
+  body
 
-* `POST /scan/invalidateBatch` invalidates a batch
-  * `batchId`
+- `POST /scan/invalidateBatch` invalidates a batch
 
-* `POST /scan/scanBatch` scans a batch of ballots and stores them in the scanner's database
+  - `batchId`
 
-* `POST /scan/export` return all the CVRs as an attachment
+- `POST /scan/scanBatch` scans a batch of ballots and stores them in the
+  scanner's database
 
-* `POST /scan/zero` zero's all data but not the election config
+- `POST /scan/export` return all the CVRs as an attachment
 
-* `POST /scan/unconfigure` removes all configuration information and data
+- `POST /scan/zero` zero's all data but not the election config
+
+- `POST /scan/unconfigure` removes all configuration information and data
 
 ## Architecture
-
-

--- a/README.md
+++ b/README.md
@@ -8,15 +8,8 @@ This web server component provides a web interface to a scanner
 # install application packages
 yarn install
 
-# install external tools (macOS)
-if [ "$(uname)" = "Darwin" ]; then
-  brew install zbar
-fi
-
-# install external tools (linux)
-if [ "$(uname)" = "Linux" ]; then
-  sudo apt-get install -y zbar-tools
-fi
+# install external tools
+make install
 ```
 
 ## Run Tests


### PR DESCRIPTION
The tests were failing on a fresh clone because `zbarimg` was not installed and the code invoking it essentially ignores the error.

https://github.com/votingworks/module-scan/blob/5287a71a63ddfa17987cdf611cbf47e0cd01cf8e/src/interpreter.ts#L98-L102

This binary is provided by the `zbar` package on macOS (via Homebrew) or `zbar-tools` on Ubuntu. This commit updates the README to include instructions for installing `zbarimg`, which fixes the tests.

Fixes https://github.com/votingworks/module-scan/issues/21