### PR TITLE
refactor: use `execFile` instead of `exec`

### DIFF
--- a/src/endToEnd.test.ts
+++ b/src/endToEnd.test.ts
@@ -10,7 +10,7 @@ jest.setTimeout(10000)
 
 jest.mock('./exec', () => ({
   __esModule: true,
-  default: jest.fn((_command, callback) => {
+  default: jest.fn((_file, _args, callback) => {
     callback()
   }),
 }))

--- a/src/exec.test.ts
+++ b/src/exec.test.ts
@@ -1,9 +1,9 @@
-import { exec as systemExec } from 'child_process'
-import exec from './exec'
+import { execFile as systemExecFile } from 'child_process'
+import execFile from './exec'
 
 jest.mock('child_process')
 
-test('exec wrapper calls exec', () => {
-  exec('ls')
-  expect(systemExec).toHaveBeenCalled()
+test('execFile wrapper calls execFile', () => {
+  execFile('ls', [])
+  expect(systemExecFile).toHaveBeenCalled()
 })

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -4,17 +4,18 @@
 // notably related to sqlite3, can't be imported at all, because
 // they use exec under the covers.
 
-import { exec as systemExec, ExecException, ChildProcess } from 'child_process'
+import { execFile as systemExecFile, ChildProcess } from 'child_process'
 
-const exec = (
-  command: string,
-  callback?: (
-    error: ExecException | null,
+const execFile = (
+  file: string,
+  args: string[],
+  callback: (
+    error: Error | null,
     stdout: string,
     stderr: string
-  ) => void
+  ) => void = () => {}
 ): ChildProcess => {
-  return systemExec(command, callback)
+  return systemExecFile(file, args, callback)
 }
 
-export default exec
+export default execFile

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -3,7 +3,7 @@
 // and process/interpret them into a cast-vote record.
 //
 
-import { exec, ExecException } from 'child_process'
+import { execFile, ExecException } from 'child_process'
 
 import {
   BallotStyle,
@@ -94,8 +94,9 @@ export default function interpretFile(
 ) {
   const { election, ballotImagePath, cvrCallback } = interpretFileParams
 
-  exec(
-    `zbarimg -q --raw ${ballotImagePath}`,
+  execFile(
+    'zbarimg',
+    ['-q', '--raw', ballotImagePath],
     (exc: ExecException | null, stdout: string) => {
       if (exc) {
         return cvrCallback({ ballotImagePath })

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -12,7 +12,7 @@ const mockChokidar = chokidar as jest.Mocked<typeof chokidar>
 let execErrorMessage: string | undefined = undefined
 jest.mock('./exec', () => ({
   __esModule: true,
-  default: jest.fn((_command, callback) => {
+  default: jest.fn((_file, _args, callback) => {
     callback(execErrorMessage)
   }),
 }))

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -20,7 +20,7 @@ import {
 } from './store'
 import interpretFile, { interpretBallotString } from './interpreter'
 
-import exec from './exec'
+import execFile from './exec'
 
 let manualBatchId: number | undefined
 
@@ -108,6 +108,18 @@ export function configure(newElection: Election) {
   watcher.on('add', fileAdded)
 }
 
+function zeroPad(number: number, maxLength: number = 2): string {
+  return number.toString().padStart(maxLength, '0')
+}
+
+function dateStamp(date: Date = new Date()): string {
+  return `${zeroPad(date.getFullYear(), 4)}${zeroPad(
+    date.getMonth() + 1
+  )}${zeroPad(date.getDay())}_${zeroPad(date.getHours())}${zeroPad(
+    date.getMinutes()
+  )}${zeroPad(date.getSeconds())}`
+}
+
 export function doScan() {
   return new Promise((resolve, reject) => {
     if (!election) {
@@ -115,8 +127,17 @@ export function doScan() {
     } else {
       addBatch().then((batchId: number) => {
         // trigger a scan
-        exec(
-          `scanimage -d fujitsu --resolution 300 --format=jpeg --source="ADF Duplex" --batch=${ballotImagesPath}$(date +%Y%m%d_%H%M%S)-batch-${batchId}-ballot-%04d.jpg`,
+        execFile(
+          'scanimage',
+          [
+            '-d',
+            'fujitsu',
+            '--resolution',
+            '300',
+            '--format=jpeg',
+            '--source="ADF Duplex"',
+            `--batch=${ballotImagesPath}${dateStamp()}-batch-${batchId}-ballot-%04d.jpg`,
+          ],
           err => {
             if (err) {
               // node couldn't execute the command


### PR DESCRIPTION
`exec` is vulnerable to command injection, i.e. if someone manages to control the parameters they can execute arbitrary code on the system. It's best avoided altogether, in my opinion.