### PR TITLE
fix: ensure duplex scanning works

### DIFF
--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -28,7 +28,7 @@ export class FujitsuScanner implements Scanner {
       '--resolution',
       '300',
       '--format=jpeg',
-      '--source="ADF Duplex"',
+      '--source=ADF Duplex',
       `--batch=${join(directory, `${prefix}${dateStamp()}-ballot-%04d.jpg`)}`,
     ])
   }


### PR DESCRIPTION

When we were using `exec`, we had quotes around `ADF Duplex` to ensure that the shell grouped it as part of a single argument. However, the quotes were not part of the argument actually passed to `scanimage`. We can simply remove the quotes since we're passing the arguments exactly as we mean for them to be passed.