### PR TITLE
refactor: build CVRs directly from a completed ballot

### DIFF
--- a/src/endToEnd.test.ts
+++ b/src/endToEnd.test.ts
@@ -7,6 +7,7 @@ import election from '../election.json'
 import SystemImporter from './importer'
 import Store from './store'
 import { FujitsuScanner, Scanner } from './scanner'
+import { CastVoteRecord } from './types'
 
 const sampleBallotImagesPath = path.join(
   __dirname,
@@ -150,12 +151,12 @@ test('going through the whole process works', async () => {
   // response is a few lines, each JSON.
   // can't predict the order so can't compare
   // to expected outcome as a string directly.
-  const CVRs: { _serialNumber: string }[] = exportResponse.text
+  const CVRs: CastVoteRecord[] = exportResponse.text
     .split('\n')
     .map(line => JSON.parse(line))
-  const serialNumbers = CVRs.map(cvr => cvr._serialNumber)
-  serialNumbers.sort()
-  expect(JSON.stringify(serialNumbers)).toBe(
+  const ballotIds = CVRs.map(cvr => cvr._ballotId)
+  ballotIds.sort()
+  expect(JSON.stringify(ballotIds)).toBe(
     JSON.stringify([
       '85lnPkvfNEytP3Z8gMoEcA',
       'QZZeZdTBy8/RwGnoH6/mkw', // v1 encoding

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -104,7 +104,7 @@ export default class SystemImporter implements Importer {
     })
 
     if (cvr) {
-      this.addCVR(this.manualBatchId!, 'manual-' + cvr['_serialNumber'], cvr)
+      this.addCVR(this.manualBatchId!, 'manual-' + cvr['_ballotId'], cvr)
     }
   }
 

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -7,7 +7,7 @@ import { Election } from '@votingworks/ballot-encoder'
 
 import { CVRCallbackParams, CastVoteRecord, BatchInfo } from './types'
 import Store from './store'
-import interpretFile, { interpretBallotString } from './interpreter'
+import interpretFile, { interpretBallotData } from './interpreter'
 import { Scanner } from './scanner'
 
 interface CVRCallbackWithBatchIDParams extends CVRCallbackParams {
@@ -98,7 +98,7 @@ export default class SystemImporter implements Importer {
       this.manualBatchId = await this.store.addBatch()
     }
 
-    const cvr = interpretBallotString({
+    const cvr = interpretBallotData({
       election: this.election,
       encodedBallot,
     })

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -34,7 +34,11 @@ export function ballotToCastVoteRecord(
   const contests = getContests({ ballotStyle, election })
 
   // prepare the CVR
-  const cvr: CastVoteRecord = {}
+  const cvr: CastVoteRecord = {
+    _precinctId: precinct.id,
+    _ballotId: ballotId,
+    _ballotStyleId: ballotStyle.id,
+  }
 
   for (const contest of contests) {
     // no answer for a particular contest is recorded in our final dictionary as an empty string
@@ -57,9 +61,6 @@ export function ballotToCastVoteRecord(
 
     cvr[contest.id] = cvrForContest
   }
-
-  cvr['_precinctId'] = precinct.id
-  cvr['_serialNumber'] = ballotId
 
   return cvr
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,11 @@ export interface Dictionary<T> {
   [key: string]: T | undefined
 }
 
-export type CastVoteRecord = Dictionary<string | string[]>
+export interface CastVoteRecord extends Dictionary<string | string[]> {
+  _precinctId: string
+  _ballotId: string
+  _ballotStyleId: string
+}
 
 export interface CVRCallbackParams {
   ballotImagePath: string


### PR DESCRIPTION
Now we no longer require going through v0 ballot encoding to generate CVRs.