### PR TITLE
fix: log to stderr when an import fails

### DIFF
--- a/src/importer.ts
+++ b/src/importer.ts
@@ -123,13 +123,21 @@ export default class SystemImporter implements Importer {
         pollInterval: 200,
       },
     })
-    this.watcher.on('add', path => this.fileAdded(path))
+    this.watcher.on('add', async path => {
+      try {
+        await this.fileAdded(path)
+      } catch (error) {
+        process.stderr.write(
+          `unable to process file (${path}): ${error.stack}\n`
+        )
+      }
+    })
   }
 
   /**
    * Callback for chokidar to inform us that a new file was seen.
    */
-  private fileAdded(ballotImagePath: string) {
+  private async fileAdded(ballotImagePath: string) {
     if (!this.election) {
       return
     }
@@ -144,7 +152,7 @@ export default class SystemImporter implements Importer {
 
     const batchId = parseInt(batchIdMatch[1])
 
-    interpretFile({
+    await interpretFile({
       election: this.election,
       ballotImagePath,
       cvrCallback: ({ ballotImagePath, cvr }: CVRCallbackParams) => {


### PR DESCRIPTION

Rather than simply letting a promise rejection go unhandled, which in some later version of node will crash the process, we now bubble errors up and log them.