### PR TITLE
build: remove unnecessary `git add` from lint-staged config

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,16 +20,13 @@
   },
   "lint-staged": {
     "*.+(css|graphql|json|less|md|mdx|sass|scss|yaml|yml)": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ],
     "*.+(js|jsx|ts|tsx)": [
-      "eslint --quiet --fix",
-      "git add"
+      "eslint --quiet --fix"
     ],
     "package.json": [
-      "sort-package-json",
-      "git add"
+      "sort-package-json"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
Removes this warning when committing:

```
Some of your tasks use `git add` command. Please remove it from the config since all modifications made by tasks will be automatically added to the git commit index.
```