### PR TITLE
feat: add test mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ This scanner module provides the following API:
   }
   ```
 
-- `PUT /config/election` configures the scanner with an `election.json` as the
-  body
+- `PATCH /config` configures `election` with an `election.json` or `testMode`
 
 - `POST /scan/invalidateBatch` invalidates a batch
 
@@ -61,7 +60,5 @@ This scanner module provides the following API:
 - `DELETE /scan/batch/:batchId` delete a batch by ID
 
 - `POST /scan/zero` zero's all data but not the election config
-
-- `DELETE /config/election` removes all configuration information and data
 
 ## Architecture

--- a/index.html
+++ b/index.html
@@ -765,9 +765,9 @@
 
     
     function doConfigure() {
-    fetch('/config/election', {
+    fetch('/config', {
     method: 'PUT',
-    body: JSON.stringify(election),
+    body: JSON.stringify({ election }),
     headers: {
     'Content-Type': 'application/json'
     }

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,9 +13,9 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 76,
-      functions: 94,
+      functions: 95,
       lines: 91,
-      statements: 91,
+      statements: 92,
     },
   },
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@votingworks/ballot-encoder": "^1.2.0",
-    "@votingworks/hmpb-interpreter": "^3.2.0",
+    "@votingworks/hmpb-interpreter": "^3.3.1",
     "@votingworks/qrdetect": "^1.0.1",
     "busboy": "^0.3.1",
     "canvas": "^2.6.1",

--- a/src/endToEnd.test.ts
+++ b/src/endToEnd.test.ts
@@ -59,8 +59,8 @@ test('going through the whole process works', async () => {
   }
 
   await request(app)
-    .put('/config/election')
-    .send(election)
+    .patch('/config')
+    .send({ election })
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/json')
     .expect(200, { status: 'ok' })
@@ -215,5 +215,6 @@ test('going through the whole process works', async () => {
   }
 
   // clean up
-  await request(app).delete('/config/election')
+  // eslint-disable-next-line no-null/no-null
+  await request(app).patch('/config').send({ election: null })
 })

--- a/src/endToEndHmpb.test.ts
+++ b/src/endToEndHmpb.test.ts
@@ -40,8 +40,8 @@ test('going through the whole process works', async () => {
   const waiter = getScannerCVRCountWaiter(importer)
 
   await request(app)
-    .put('/config/election')
-    .send(election)
+    .patch('/config')
+    .send({ election })
     .set('Content-Type', 'application/json')
     .set('Accept', 'application/json')
     .expect(200, { status: 'ok' })
@@ -49,6 +49,19 @@ test('going through the whole process works', async () => {
   await request(app)
     .post('/scan/hmpb/addTemplates')
     .attach('ballots', join(electionFixturesRoot, 'ballot.pdf'))
+    .attach(
+      'metadatas',
+      Buffer.from(
+        new TextEncoder().encode(
+          JSON.stringify({
+            ballotStyleId: '77',
+            precinctId: '42',
+            isTestBallot: false,
+          })
+        )
+      ),
+      { filename: 'metadata.json', contentType: 'application/json' }
+    )
     .expect(200)
 
   await request(app).post('/scan/scanBatch').expect(200, { status: 'ok' })

--- a/src/importer.test.ts
+++ b/src/importer.test.ts
@@ -6,6 +6,7 @@ import { Scanner } from './scanner'
 import makeTemporaryBallotImportImageDirectories, {
   TemporaryBallotImportImageDirectories,
 } from './util/makeTemporaryBallotImportImageDirectories'
+import { makeMockInterpreter } from '../test/util/mocks'
 
 jest.mock('chokidar')
 const mockChokidar = chokidar as jest.Mocked<typeof chokidar>
@@ -37,7 +38,7 @@ test('doImport calls scanner.scanInto', async () => {
     close: mockWatcherClose,
   } as unknown) as chokidar.FSWatcher)
 
-  importer.configure(election)
+  await importer.configure(election)
 
   expect(mockWatcherOn).toHaveBeenCalled()
 
@@ -65,4 +66,58 @@ test('configure starts watching files', async () => {
   })
   await importer.configure(election)
   await importer.unconfigure()
+})
+
+test('setTestMode zeroes and sets test mode on the interpreter', async () => {
+  const scanner: Scanner = { scanInto: jest.fn().mockResolvedValue(undefined) }
+  const importer = new SystemImporter({
+    ...importDirs.paths,
+    store: await Store.memoryStore(),
+    scanner,
+  })
+
+  await importer.configure(election)
+  await importer.addManualBallot(
+    new TextEncoder().encode(
+      '12.23.1|0|0|0||||||||||||||||.r6UYR4t7hEFMz8ZlMWf1Sw'
+    )
+  )
+  expect((await importer.getStatus()).batches).toHaveLength(1)
+
+  await importer.setTestMode(true)
+  expect((await importer.getStatus()).batches).toHaveLength(0)
+})
+
+test('restoreConfig reads config data from the store', async () => {
+  const scanner: Scanner = { scanInto: jest.fn().mockResolvedValue(undefined) }
+  const store = await Store.memoryStore()
+  const interpreter = makeMockInterpreter()
+  const importer = new SystemImporter({
+    ...importDirs.paths,
+    store,
+    scanner,
+    interpreter,
+  })
+
+  await store.setElection(election)
+  await store.setTestMode(true)
+  await store.addHmpbTemplate(Buffer.of(1), {
+    ballotStyleId: '77',
+    precinctId: '42',
+    isTestBallot: true,
+  })
+  await store.addHmpbTemplate(Buffer.of(2), {
+    ballotStyleId: '77',
+    precinctId: '43',
+    isTestBallot: true,
+  })
+
+  jest.spyOn(importer, 'configure').mockResolvedValue()
+  jest.spyOn(importer, 'addHmpbTemplates').mockResolvedValue([])
+
+  await importer.restoreConfig()
+  expect(importer.configure).toHaveBeenCalledWith(election)
+  expect(importer.addHmpbTemplates).toHaveBeenNthCalledWith(1, Buffer.of(1))
+  expect(importer.addHmpbTemplates).toHaveBeenNthCalledWith(2, Buffer.of(2))
+  expect(interpreter.setTestMode).toHaveBeenCalledWith(true)
 })

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,3 +1,5 @@
+import { promises as fs } from 'fs'
+import * as tmp from 'tmp'
 import Store from './store'
 import election from '../test/fixtures/hmpb-dallas-county/election'
 
@@ -11,6 +13,18 @@ test('get/set election', async () => {
 
   await store.setElection(undefined)
   expect(await store.getElection()).toBeUndefined()
+})
+
+test('get/set test mode', async () => {
+  const store = await Store.memoryStore()
+
+  expect(await store.getTestMode()).toBe(false)
+
+  await store.setTestMode(true)
+  expect(await store.getTestMode()).toBe(true)
+
+  await store.setTestMode(false)
+  expect(await store.getTestMode()).toBe(false)
 })
 
 test('HMPB template handling', async () => {
@@ -34,4 +48,15 @@ test('HMPB template handling', async () => {
       },
     ],
   ])
+})
+
+test('destroy database', async () => {
+  const dbFile = tmp.fileSync()
+  const store = new Store(dbFile.name)
+
+  await store.init()
+  await fs.access(dbFile.name)
+
+  await store.dbDestroy()
+  await expect(fs.access(dbFile.name)).rejects.toThrowError('ENOENT')
 })

--- a/test/util/mocks.ts
+++ b/test/util/mocks.ts
@@ -1,0 +1,26 @@
+import { Importer } from '../../src/importer'
+import { Interpreter } from '../../src/interpreter'
+
+export function makeMockInterpreter(): jest.Mocked<Interpreter> {
+  return {
+    addHmpbTemplate: jest.fn(),
+    interpretFile: jest.fn(),
+    setTestMode: jest.fn(),
+  }
+}
+
+export function makeMockImporter(): jest.Mocked<Importer> {
+  return {
+    addHmpbTemplate: jest.fn(),
+    addHmpbTemplates: jest.fn(),
+    addManualBallot: jest.fn(),
+    configure: jest.fn(),
+    doExport: jest.fn(),
+    doImport: jest.fn(),
+    doZero: jest.fn(),
+    getStatus: jest.fn(),
+    restoreConfig: jest.fn(),
+    setTestMode: jest.fn(),
+    unconfigure: jest.fn(),
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -947,10 +947,10 @@
   resolved "https://registry.yarnpkg.com/@votingworks/ballot-encoder/-/ballot-encoder-1.2.0.tgz#e2721f2f009d5f5d333baf9d7e162960623f7157"
   integrity sha512-TlCfcO2agFz9qS1vg3JqLGuTuxG46qD5HSMiLs3PooQ6mOMifEXOzEYkY/cv71xaSCxSy621DKfB/ilYX6TNwA==
 
-"@votingworks/hmpb-interpreter@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@votingworks/hmpb-interpreter/-/hmpb-interpreter-3.2.0.tgz#b4e40ad41670dc219b303babb2e0d8d06b62df65"
-  integrity sha512-2LtPUH24zmShu05TxXooldu1SUz6umAZsOeyHRbD3lIW6VG1mIuUjLE26M08u1URhJUkLfMxemBulSfMMHRJ0A==
+"@votingworks/hmpb-interpreter@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@votingworks/hmpb-interpreter/-/hmpb-interpreter-3.3.1.tgz#e91c2e51ec8fe729d7aa6da6adcd4cf7320bc05d"
+  integrity sha512-TTOHg0DUDj7Cox6X7yQ+SoYyKEmzdeWBGP8yrIoXJXRTnIBaipqnwy0ujoiTYv7DwCx2auu5grVbPxODiIzZvA==
   dependencies:
     "@votingworks/ballot-encoder" "^1.2.0"
     canvas "^2.6.1"


### PR DESCRIPTION
- moved all config to `/config` endpoint
- fixed an issue with the database being destroyed on startup
- recreates the underlying interpreter on toggling test mode
- moves reloading of configuration out of `start` to allow it to be called on test mode toggle