### PR TITLE
fix: detect quirc decode errors

### DIFF
--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -133,10 +133,10 @@ export async function getBallotImageData(
   const file = await readFile(filepath)
   const { data, width, height } = decodeJpeg(file)
   const image = { data: Uint8ClampedArray.from(data), width, height }
-  const quircCodes = await quircDecode(file)
+  const [quircCode] = await quircDecode(file)
 
-  if (quircCodes.length > 0) {
-    return { file, image, qrcode: quircCodes[0].data }
+  if (quircCode && 'data' in quircCode) {
+    return { file, image, qrcode: quircCode.data }
   }
 
   const qrdetectCodes = qrdetect(data, width, height)

--- a/types/node-quirc.d.ts
+++ b/types/node-quirc.d.ts
@@ -15,6 +15,8 @@ declare module 'node-quirc' {
     MODE_KANJI: 'KANJI'
   }
 
+  type DecodeResult = (QRCode | DecodeError)[]
+
   interface QRCode {
     version: number
     // eslint-disable-next-line camelcase
@@ -32,11 +34,15 @@ declare module 'node-quirc' {
     data: Buffer
   }
 
+  interface DecodeError {
+    err: string
+  }
+
   // eslint-disable-next-line import/export
-  export function decode(img: Buffer): Promise<QRCode[]>
+  export function decode(img: Buffer): Promise<DecodeResult>
   // eslint-disable-next-line import/export
   export function decode(
     img: Buffer,
-    callback: (err: Error, results: QRCode[]) => void
-  ): Promise<QRCode[]>
+    callback: (err: Error, results: DecodeResult) => void
+  ): Promise<DecodeResult>
 }


### PR DESCRIPTION
Sometimes quirc will find a QR code but be unable to decode it (e.g. an "ECC failure"). When this happens, an entry in the returned list is still created but it has a different structure. This commit updates the types to match the reality of what could be returned.

https://github.com/dlbeer/quirc/blob/c89d949371f5f0fd8546d5263e930938a0f84b8b/lib/decode.c#L333