### PR TITLE
refactor: clarify values for mark status

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,16 +1,17 @@
 import { CandidateContest, YesNoContest } from '@votingworks/ballot-encoder'
-import election from '../test/fixtures/state-of-hamilton/election'
+import { createImageData } from 'canvas'
 import { Application } from 'express'
 import { promises as fs } from 'fs'
 import { Server } from 'http'
 import { join } from 'path'
 import request from 'supertest'
+import election from '../test/fixtures/state-of-hamilton/election'
+import zeroRect from '../test/fixtures/zeroRect'
 import { makeMockImporter } from '../test/util/mocks'
 import { Importer } from './importer'
 import { buildApp, start } from './server'
 import Store from './store'
-import { createImageData } from 'canvas'
-import zeroRect from '../test/fixtures/zeroRect'
+import { MarkStatus } from './types/ballot-review'
 
 jest.mock('./importer')
 
@@ -272,7 +273,7 @@ test.only('GET /scan/hmpb/ballot/:ballotId', async () => {
         url: '/scan/hmpb/ballot/1',
         image: { url: '/scan/hmpb/ballot/1/image', width: 0, height: 0 },
       },
-      marks: { president: { 'barchi-hallaren': true } },
+      marks: { president: { 'barchi-hallaren': MarkStatus.Marked } },
       contests: [],
     })
 })

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -4,6 +4,7 @@ import * as tmp from 'tmp'
 import election from '../test/fixtures/state-of-hamilton/election'
 import zeroRect from '../test/fixtures/zeroRect'
 import Store from './store'
+import { MarkStatus } from './types/ballot-review'
 
 test('get/set election', async () => {
   const store = await Store.memoryStore()
@@ -223,22 +224,22 @@ test('adjudication', async () => {
   expect(await store.getBallot(ballotId)).toEqual(
     expect.objectContaining({
       marks: {
-        [candidateContest.id]: { [candidateOption.id]: false },
-        [yesnoContest.id]: { [yesnoOption]: true },
+        [candidateContest.id]: { [candidateOption.id]: MarkStatus.Unmarked },
+        [yesnoContest.id]: { [yesnoOption]: MarkStatus.Marked },
       },
     })
   )
 
   await store.saveBallotAdjudication(ballotId, {
-    [candidateContest.id]: { [candidateOption.id]: true },
-    [yesnoContest.id]: { [yesnoOption]: false },
+    [candidateContest.id]: { [candidateOption.id]: MarkStatus.Marked },
+    [yesnoContest.id]: { [yesnoOption]: MarkStatus.Unmarked },
   })
 
   expect(await store.getBallot(ballotId)).toEqual(
     expect.objectContaining({
       marks: {
-        [candidateContest.id]: { [candidateOption.id]: true },
-        [yesnoContest.id]: { [yesnoOption]: false },
+        [candidateContest.id]: { [candidateOption.id]: MarkStatus.Marked },
+        [yesnoContest.id]: { [yesnoOption]: MarkStatus.Unmarked },
       },
     })
   )

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,8 +9,8 @@ import {
   getContests,
 } from '@votingworks/ballot-encoder'
 import {
-  BallotPageMetadata,
   BallotLocales,
+  BallotPageMetadata,
 } from '@votingworks/hmpb-interpreter'
 import { strict as assert } from 'assert'
 import makeDebug from 'debug'
@@ -22,16 +22,16 @@ import {
   BallotInfo,
   BatchInfo,
   CastVoteRecord,
+  getMarkStatus,
   SerializableBallotPageLayout,
-  isMarked,
 } from './types'
 import {
   CandidateContestOption,
   Contest,
   ContestOption,
+  MarksByContestId,
   ReviewBallot,
   YesNoContestOption,
-  MarksByContestId,
 } from './types/ballot-review'
 import applyChangesToMarks from './util/applyChangesToMarks'
 
@@ -582,9 +582,7 @@ export default class Store {
                     typeof mark.option === 'string'
                       ? mark.option
                       : mark.option.id
-                  ] ??
-                  isMarked(mark) ??
-                  false,
+                  ] ?? getMarkStatus(mark),
               },
             },
       {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,13 @@
-import { BallotStyle, Precinct, Contest } from '@votingworks/ballot-encoder'
+import { BallotStyle, Contest, Precinct } from '@votingworks/ballot-encoder'
 import {
+  BallotLocales,
   BallotMark,
   BallotPageLayout,
   BallotPageMetadata,
   BallotTargetMark,
-  BallotLocales,
 } from '@votingworks/hmpb-interpreter'
 import { MarkInfo } from './interpreter'
+import { MarkStatus } from './types/ballot-review'
 
 export interface Dictionary<T> {
   [key: string]: T | undefined
@@ -88,19 +89,19 @@ export interface BallotConfig extends BallotStyleData {
 
 export * from './types/ballot-review'
 
-export function isMarked(
+export function getMarkStatus(
   mark: BallotTargetMark,
-  { marginalMarkMin = 0.1, validMarkMin = 0.2 } = {}
-): boolean | undefined {
+  { marginalMarkMin = 0.12, validMarkMin = 0.5 } = {}
+): MarkStatus {
   if (mark.score >= validMarkMin) {
-    return true
+    return MarkStatus.Marked
   }
 
   if (mark.score < marginalMarkMin) {
-    return false
+    return MarkStatus.Unmarked
   }
 
-  return undefined
+  return MarkStatus.Marginal
 }
 
 export function isMarginalMark(
@@ -112,6 +113,7 @@ export function isMarginalMark(
 ): boolean {
   return (
     mark.type !== 'stray' &&
-    typeof isMarked(mark, { marginalMarkMin, validMarkMin }) === 'undefined'
+    getMarkStatus(mark, { marginalMarkMin, validMarkMin }) ===
+      MarkStatus.Marginal
   )
 }

--- a/src/types/ballot-review.ts
+++ b/src/types/ballot-review.ts
@@ -8,7 +8,13 @@ export interface MarksByContestId {
 }
 
 export interface MarksByOptionId {
-  [key: string]: boolean | undefined
+  [key: string]: MarkStatus | undefined
+}
+
+export enum MarkStatus {
+  Marked = 'marked',
+  Unmarked = 'unmarked',
+  Marginal = 'marginal',
 }
 
 export interface ReviewBallot {

--- a/src/util/applyChangesToMarks.test.ts
+++ b/src/util/applyChangesToMarks.test.ts
@@ -4,6 +4,7 @@ import {
   YesNoContest,
 } from '@votingworks/ballot-encoder'
 import zeroRect from '../../test/fixtures/zeroRect'
+import { MarkStatus } from '../types/ballot-review'
 import applyChangesToMarks from './applyChangesToMarks'
 
 test('returns an empty object when no changes are given', () => {
@@ -120,11 +121,14 @@ test('returns the subset of the changes that differ from the original marks', ()
       ],
 
       {
-        [contest.id]: { [option1.id]: false, [option2.id]: true },
+        [contest.id]: {
+          [option1.id]: MarkStatus.Unmarked,
+          [option2.id]: MarkStatus.Marked,
+        },
       }
     )
   ).toEqual({
-    [contest.id]: { [option1.id]: false },
+    [contest.id]: { [option1.id]: MarkStatus.Unmarked },
   })
 })
 
@@ -150,8 +154,8 @@ test('takes the last value for a given option', () => {
         },
       ],
 
-      { [contest.id]: { [option.id]: false } },
-      { [contest.id]: { [option.id]: true } }
+      { [contest.id]: { [option.id]: MarkStatus.Unmarked } },
+      { [contest.id]: { [option.id]: MarkStatus.Marked } }
     )
   ).toEqual({})
 })
@@ -183,7 +187,7 @@ test('does not factor stray marks into the result', () => {
           bounds: zeroRect,
         },
       ],
-      { [contest.id]: { [option.id]: false } }
+      { [contest.id]: { [option.id]: MarkStatus.Unmarked } }
     )
-  ).toEqual({ [contest.id]: { [option.id]: false } })
+  ).toEqual({ [contest.id]: { [option.id]: MarkStatus.Unmarked } })
 })

--- a/src/util/applyChangesToMarks.ts
+++ b/src/util/applyChangesToMarks.ts
@@ -1,5 +1,5 @@
 import { BallotMark } from '@votingworks/hmpb-interpreter'
-import { isMarked } from '../types'
+import { getMarkStatus } from '../types'
 import { MarksByContestId } from '../types/ballot-review'
 
 export default function applyChangesToMarks(
@@ -13,13 +13,13 @@ export default function applyChangesToMarks(
       const contestId = mark.contest.id
       const optionId =
         typeof mark.option === 'string' ? mark.option : mark.option.id
-      const originallyMarked = isMarked(mark) === true
+      const originalMark = getMarkStatus(mark)
       const reduced = changes.reduce(
         (last, change) => change[contestId]?.[optionId] ?? last,
-        originallyMarked
+        originalMark
       )
 
-      if (reduced !== originallyMarked) {
+      if (reduced !== originalMark) {
         result[contestId] = {
           ...result[contestId],
           [optionId]: reduced,


### PR DESCRIPTION
BREAKING CHANGE. Rather than using true/false/undefined to mean marked/unmarked/marginal, we now use an enum with those values.