### PR TITLE
test: remove accidental focused test

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended', // Uses the recommended rules from @typescript-eslint/eslint-plugin
     'prettier/@typescript-eslint', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
     'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
+    'plugin:jest/recommended',
   ],
   globals: {
     Atomics: 'readonly',

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-cypress": "^2.10.3",
     "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-jest": "^23.10.0",
+    "eslint-plugin-jest": "^23.18.0",
     "eslint-plugin-prettier": "^3.1.3",
     "husky": "^4.2.5",
     "jest": "^26.0.1",

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable jest/expect-expect */
+
 import { CandidateContest, YesNoContest } from '@votingworks/ballot-encoder'
 import { createImageData } from 'canvas'
 import { Application } from 'express'
@@ -223,7 +225,7 @@ test('GET /scan/batch/:batchId 404', async () => {
     .expect(404)
 })
 
-test.only('GET /scan/hmpb/ballot/:ballotId', async () => {
+test('GET /scan/hmpb/ballot/:ballotId', async () => {
   const contest = election.contests.find(
     ({ type }) => type === 'candidate'
   ) as CandidateContest
@@ -304,6 +306,8 @@ test('PATCH /scan/hmpb/ballot/:ballotId', async () => {
       _precinctId: '23',
       _scannerId: 'def',
       _testBallot: false,
+      _pageNumber: 1,
+      _locales: { primary: 'en-US' },
     },
     {
       ballotSize: { width: 0, height: 0 },
@@ -332,14 +336,15 @@ test('PATCH /scan/hmpb/ballot/:ballotId', async () => {
       isTestBallot: false,
       pageNumber: 1,
       pageCount: 1,
+      locales: { primary: 'en-US' },
     }
   )
   await store.finishBatch(batchId)
   await request(app)
     .patch(`/scan/hmpb/ballot/${ballotId}`)
     .send({
-      [candidateContest.id]: { [candidateOption.id]: false },
-      [yesnoContest.id]: { [yesnoOption]: true },
+      [candidateContest.id]: { [candidateOption.id]: MarkStatus.Unmarked },
+      [yesnoContest.id]: { [yesnoOption]: MarkStatus.Marked },
     })
     .expect(200, { status: 'ok' })
 
@@ -355,8 +360,8 @@ test('PATCH /scan/hmpb/ballot/:ballotId', async () => {
         },
       },
       marks: {
-        [candidateContest.id]: { [candidateOption.id]: false },
-        [yesnoContest.id]: { [yesnoOption]: true },
+        [candidateContest.id]: { [candidateOption.id]: MarkStatus.Unmarked },
+        [yesnoContest.id]: { [yesnoOption]: MarkStatus.Marked },
       },
       contests: [],
     })
@@ -365,7 +370,7 @@ test('PATCH /scan/hmpb/ballot/:ballotId', async () => {
   await request(app)
     .patch(`/scan/hmpb/ballot/${ballotId}`)
     .send({
-      [candidateContest.id]: { [candidateOption.id]: true },
+      [candidateContest.id]: { [candidateOption.id]: MarkStatus.Marked },
     })
     .expect(200, { status: 'ok' })
   await request(app)
@@ -380,8 +385,8 @@ test('PATCH /scan/hmpb/ballot/:ballotId', async () => {
         },
       },
       marks: {
-        [candidateContest.id]: { [candidateOption.id]: true },
-        [yesnoContest.id]: { [yesnoOption]: true },
+        [candidateContest.id]: { [candidateOption.id]: MarkStatus.Marked },
+        [yesnoContest.id]: { [yesnoOption]: MarkStatus.Marked },
       },
       contests: [],
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2200,10 +2200,10 @@ eslint-plugin-import@^2.20.2:
     read-pkg-up "^2.0.0"
     resolve "^1.12.0"
 
-eslint-plugin-jest@^23.10.0:
-  version "23.10.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.10.0.tgz#4738c7ca9e6513da50f4e99d7b161c1f82fa8e8f"
-  integrity sha512-cHC//nesojSO1MLxVmFJR/bUaQQG7xvMHQD8YLbsQzevR41WKm8paKDUv2wMHlUy5XLZUmNcWuflOi4apS8D+Q==
+eslint-plugin-jest@^23.18.0:
+  version "23.18.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.18.0.tgz#4813eacb181820ed13c5505f400956d176b25af8"
+  integrity sha512-wLPM/Rm1SGhxrFQ2TKM/BYsYPhn7ch6ZEK92S2o/vGkAAnDXM0I4nTIo745RIX+VlCRMFgBuJEax6XfTHMdeKg==
   dependencies:
     "@typescript-eslint/experimental-utils" "^2.5.0"
 


### PR DESCRIPTION
I had added an `.only` to run a specific test, but accidentally left it in. This removes the `.only`, fixes the tests that were failing silently in this file, and enables the recommended jest eslint rules (such as the one preventing the use of `.only`).