### PR TITLE
feat: allow scanning ballot images from files

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,796 +1,91 @@
 <html>
-  <head><title>Test Page for Scan</title></head>
+  <head>
+    <title>Test Page for Scan</title>
+  </head>
   <script>
-    function get_status() {
-    fetch('/scan/status')
-    .then(function(response) {
-    return response.json();
-    })
-    .then(function(responseJSON) {
-    document.getElementById('result').value=JSON.stringify(responseJSON)
-    })
+    // @ts-check
+
+    async function getStatus() {
+      const textArea = /** @type {HTMLTextAreaElement} */ (document.getElementById(
+        'result'
+      ))
+      textArea.value = await (await fetch('/scan/status')).text()
     }
 
-    window.setInterval(get_status, 2000)
-
+    window.setInterval(getStatus, 2000)
 
     function doScan() {
-    fetch('/scan/scanBatch', {
-        method: 'POST'
-    })
+      fetch('/scan/scanBatch', {
+        method: 'POST',
+      })
     }
 
-    election = {
-  "title": "2020 General Election",
-  "state": "State of Hamilton",
-  "county": "Franklin County",
-  "date": "Tuesday, November 3, 2020",
-  "districts": [
-    {
-      "id": "district-1",
-      "name": "District 1"
-    },
-    {
-      "id": "district-2",
-      "name": "District 2"
-    },
-    {
-      "id": "district-3",
-      "name": "District 3"
-    },
-    {
-      "id": "7",
-      "name": "District 7"
+    function browseFileImagesToScan() {
+      const scanFilesInput = document.getElementById('scan-files-input')
+      scanFilesInput.click()
     }
-  ],
-  "parties": [
-    {
-      "id": "0",
-      "name": "Federalist",
-      "abbrev": "F"
-    },
-    {
-      "id": "1",
-      "name": "People's",
-      "abbrev": "P"
-    },
-    {
-      "id": "2",
-      "name": "Liberty",
-      "abbrev": "Li"
-    },
-    {
-      "id": "3",
-      "name": "Constitution",
-      "abbrev": "C"
-    },
-    {
-      "id": "4",
-      "name": "Whig",
-      "abbrev": "W"
-    },
-    {
-      "id": "5",
-      "name": "Labor",
-      "abbrev": "La"
-    },
-    {
-      "id": "6",
-      "name": "Independent",
-      "abbrev": "I"
-    }
-  ],
-  "contests": [
-    {
-      "id": "president",
-      "districtId": "district-1",
-      "type": "candidate",
-      "section": "United States",
-      "title": "President and Vice-President",
-      "seats": 1,
-      "candidates": [
-        {
-          "id": "barchi-hallaren",
-          "name": "Joseph Barchi and Joseph Hallaren",
-          "partyId": "0"
-        },
-        {
-          "id": "cramer-vuocolo",
-          "name": "Adam Cramer and Greg Vuocolo",
-          "partyId": "1"
-        },
-        {
-          "id": "court-blumhardt",
-          "name": "Daniel Court and Amy Blumhardt",
-          "partyId": "2"
-        },
-        {
-          "id": "boone-lian",
-          "name": "Alvin Boone and James Lian",
-          "partyId": "3"
-        },
-        {
-          "id": "hildebrand-garritty",
-          "name": "Ashley Hildebrand-McDougall and James Garritty",
-          "partyId": "4"
-        },
-        {
-          "id": "patterson-lariviere",
-          "name": "Martin Patterson and Clay Lariviere",
-          "partyId": "5"
-        }
-      ],
-      "allowWriteIns": false
-    },
-    {
-      "id": "senator",
-      "districtId": "district-2",
-      "type": "candidate",
-      "section": "United States",
-      "title": "Senator",
-      "seats": 1,
-      "candidates": [
-        {
-          "id": "weiford",
-          "name": "Dennis Weiford",
-          "partyId": "0"
-        },
-        {
-          "id": "garriss",
-          "name": "Lloyd Garriss",
-          "partyId": "1"
-        },
-        {
-          "id": "wentworthfarthington",
-          "name": "Sylvia Wentworth-Farthington",
-          "partyId": "2"
-        },
-        {
-          "id": "hewetson",
-          "name": "Heather Hewetson",
-          "partyId": "3"
-        },
-        {
-          "id": "martinez",
-          "name": "Victor Martinez",
-          "partyId": "4"
-        },
-        {
-          "id": "brown",
-          "name": "David Brown",
-          "partyId": "6"
-        },
-        {
-          "id": "pound",
-          "name": "David Pound",
-          "partyId": "6"
-        }
-      ],
-      "allowWriteIns": false
-    },
-    {
-      "id": "representative-district-6",
-      "districtId": "district-1",
-      "type": "candidate",
-      "section": "United States",
-      "title": "Representative, District 6",
-      "seats": 1,
-      "candidates": [
-        {
-          "id": "plunkard",
-          "name": "Brad Plunkard",
-          "partyId": "0"
-        },
-        {
-          "id": "reeder",
-          "name": "Bruce Reeder",
-          "partyId": "1"
-        },
-        {
-          "id": "schott",
-          "name": "Brad Schott",
-          "partyId": "2"
-        },
-        {
-          "id": "tawney",
-          "name": "Glen Tawney",
-          "partyId": "3"
-        },
-        {
-          "id": "forrest",
-          "name": "Carroll Forrest",
-          "partyId": "4"
-        }
-      ],
-      "allowWriteIns": false
-    },
-    {
-      "id": "governor",
-      "districtId": "district-2",
-      "type": "candidate",
-      "section": "State of Hamilton",
-      "title": "Governor",
-      "seats": 1,
-      "candidates": [
-        {
-          "id": "franz",
-          "name": "Charlene Franz",
-          "partyId": "0"
-        },
-        {
-          "id": "harris",
-          "name": "Gerald Harris",
-          "partyId": "1"
-        },
-        {
-          "id": "bargmann",
-          "name": "Linda Bargmann",
-          "partyId": "2"
-        },
-        {
-          "id": "abcock",
-          "name": "Barbara Adcock",
-          "partyId": "3"
-        },
-        {
-          "id": "steelloy",
-          "name": "Carrie Steel-Loy",
-          "partyId": "4"
-        },
-        {
-          "id": "sharp",
-          "name": "Frederick Sharp",
-          "partyId": "5"
-        },
-        {
-          "id": "wallace",
-          "name": "Alex Wallace",
-          "partyId": "6"
-        },
-        {
-          "id": "williams",
-          "name": "Barbara Williams",
-          "partyId": "6"
-        },
-        {
-          "id": "sharp-althea",
-          "name": "Althea Sharp",
-          "partyId": "6"
-        },
-        {
-          "id": "alpern",
-          "name": "Douglas Alpern",
-          "partyId": "6"
-        },
-        {
-          "id": "windbeck",
-          "name": "Ann Windbeck",
-          "partyId": "6"
-        },
-        {
-          "id": "greher",
-          "name": "Mike Greher",
-          "partyId": "6"
-        },
-        {
-          "id": "alexander",
-          "name": "Patricia Alexander",
-          "partyId": "6"
-        },
-        {
-          "id": "mitchell",
-          "name": "Kenneth Mitchell",
-          "partyId": "6"
-        },
-        {
-          "id": "lee",
-          "name": "Stan Lee",
-          "partyId": "6"
-        },
-        {
-          "id": "ash",
-          "name": "Henry Ash",
-          "partyId": "6"
-        },
-        {
-          "id": "kennedy",
-          "name": "Karen Kennedy",
-          "partyId": "6"
-        },
-        {
-          "id": "jackson",
-          "name": "Van Jackson",
-          "partyId": "6"
-        },
-        {
-          "id": "brown",
-          "name": "Debbie Brown",
-          "partyId": "6"
-        },
-        {
-          "id": "teller",
-          "name": "Joseph Teller",
-          "partyId": "6"
-        },
-        {
-          "id": "ward",
-          "name": "Greg Ward",
-          "partyId": "6"
-        },
-        {
-          "id": "murphy",
-          "name": "Lou Murphy",
-          "partyId": "6"
-        },
-        {
-          "id": "newman",
-          "name": "Jane Newman",
-          "partyId": "6"
-        },
-        {
-          "id": "callanann",
-          "name": "Jack Callanann",
-          "partyId": "6"
-        },
-        {
-          "id": "york",
-          "name": "Esther York",
-          "partyId": "6"
-        },
-        {
-          "id": "chandler",
-          "name": "Glenn Chandler",
-          "partyId": "6"
-        }
-      ],
-      "allowWriteIns": false
-    },
-    {
-      "id": "lieutenant-governor",
-      "districtId": "district-1",
-      "type": "candidate",
-      "section": "State of Hamilton",
-      "title": "Lieutenant Governor",
-      "seats": 1,
-      "candidates": [
-        {
-          "id": "norberg",
-          "name": "Chris Norberg",
-          "partyId": "0"
-        },
-        {
-          "id": "parks",
-          "name": "Anthony Parks",
-          "partyId": "1"
-        },
-        {
-          "id": "garcia",
-          "name": "Luis Jorges Garcia",
-          "partyId": "2"
-        },
-        {
-          "id": "qualey",
-          "name": "Charles Qualey",
-          "partyId": "3"
-        },
-        {
-          "id": "hovis",
-          "name": "George Hovis",
-          "partyId": "4"
-        },
-        {
-          "id": "zirkle",
-          "name": "Burt Zirkle",
-          "partyId": "5"
-        },
-        {
-          "id": "davis",
-          "name": "Brenda Davis",
-          "partyId": "6"
-        },
-        {
-          "id": "freeman",
-          "name": "Edward Freeman",
-          "partyId": "6"
-        },
-        {
-          "id": "swan",
-          "name": "Paul Swan",
-          "partyId": "6"
-        }
-      ],
-      "allowWriteIns": false
-    },
-    {
-      "id": "secretary-of-state",
-      "districtId": "district-2",
-      "type": "candidate",
-      "section": "State of Hamilton",
-      "title": "Secretary of State",
-      "seats": 1,
-      "candidates": [
-        {
-          "id": "shamsi",
-          "name": "Laila Shamsi",
-          "partyId": "0"
-        },
-        {
-          "id": "talarico",
-          "name": "Marty Talarico",
-          "partyId": "1"
-        }
-      ],
-      "allowWriteIns": false
-    },
-    {
-      "id": "state-senator-district-31",
-      "districtId": "district-1",
-      "type": "candidate",
-      "section": "State of Hamilton",
-      "title": "Senator, District 31",
-      "seats": 1,
-      "candidates": [
-        {
-          "id": "shiplett",
-          "name": "Edward Shiplett",
-          "partyId": "3"
-        }
-      ],
-      "allowWriteIns": false
-    },
-    {
-      "id": "state-assembly-district-54",
-      "districtId": "district-1",
-      "type": "candidate",
-      "section": "State of Hamilton",
-      "title": "Assembly Member, District 54",
-      "seats": 1,
-      "candidates": [
-        {
-          "id": "solis",
-          "name": "Andrea Solis",
-          "partyId": "0"
-        },
-        {
-          "id": "keller",
-          "name": "Amos Keller",
-          "partyId": "1"
-        },
-        {
-          "id": "rangel",
-          "name": "Davitra Rangel",
-          "partyId": "2"
-        }
-      ],
-      "allowWriteIns": false
-    },
-    {
-      "id": "county-commissioners",
-      "districtId": "district-2",
-      "type": "candidate",
-      "section": "Franklin County",
-      "title": "County Commissioners",
-      "seats": 4,
-      "candidates": [
-        {
-          "id": "argent",
-          "name": "Camille Argent",
-          "partyId": "0"
-        },
-        {
-          "id": "witherspoonsmithson",
-          "name": "Chloe Witherspoon-Smithson",
-          "partyId": "0"
-        },
-        {
-          "id": "bainbridge",
-          "name": "Clayton Bainbridge",
-          "partyId": "0"
-        },
-        {
-          "id": "hennessey",
-          "name": "Charlene Hennessey",
-          "partyId": "1"
-        },
-        {
-          "id": "savoy",
-          "name": "Eric Savoy",
-          "partyId": "1"
-        },
-        {
-          "id": "tawa",
-          "name": "Susan Tawa",
-          "partyId": "1"
-        },
-        {
-          "id": "tawa-mary",
-          "name": "Mary Tawa",
-          "partyId": "1"
-        },
-        {
-          "id": "rangel",
-          "name": "Damian Rangel",
-          "partyId": "2"
-        },
-        {
-          "id": "altman",
-          "name": "Valarie Altman",
-          "partyId": "3"
-        },
-        {
-          "id": "moore",
-          "name": "Helen Moore",
-          "partyId": "3"
-        },
-        {
-          "id": "white",
-          "name": "John White",
-          "partyId": "4"
-        },
-        {
-          "id": "schmidt",
-          "name": "Joe Schmidt",
-          "partyId": "4"
-        },
-        {
-          "id": "smith",
-          "name": "Joe Smith",
-          "partyId": "4"
-        },
-        {
-          "id": "marracini",
-          "name": "Amanda Marracini",
-          "partyId": "5"
-        },
-        {
-          "id": "schreiner",
-          "name": "Martin Schreiner",
-          "partyId": "6"
-        }
-      ],
-      "allowWriteIns": true
-    },
-    {
-      "id": "county-registrar-of-wills",
-      "districtId": "district-1",
-      "type": "candidate",
-      "section": "Franklin County",
-      "title": "Registrar of Wills",
-      "seats": 1,
-      "candidates": [
-        {
-          "id": "ramachandrani",
-          "name": "Rhadka Ramachandrani",
-          "partyId": "6"
-        }
-      ],
-      "allowWriteIns": true
-    },
-    {
-      "id": "city-mayor",
-      "districtId": "district-2",
-      "type": "candidate",
-      "section": "City of Springfield",
-      "title": "Mayor",
-      "seats": 1,
-      "candidates": [
-        {
-          "id": "white",
-          "name": "Orville White",
-          "partyId": "1"
-        },
-        {
-          "id": "seldon",
-          "name": "Gregory Seldon",
-          "partyId": "2"
-        }
-      ],
-      "allowWriteIns": true
-    },
-    {
-      "id": "city-council",
-      "districtId": "district-2",
-      "type": "candidate",
-      "section": "City of Springfield",
-      "title": "City Council",
-      "seats": 3,
-      "candidates": [
-        {
-          "id": "eagle",
-          "name": "Harvey Eagle",
-          "partyId": "0"
-        },
-        {
-          "id": "rupp",
-          "name": "Randall Rupp",
-          "partyId": "0"
-        },
-        {
-          "id": "shry",
-          "name": "Carroll Shry",
-          "partyId": "0"
-        },
-        {
-          "id": "barker",
-          "name": "Beverly Barker",
-          "partyId": "1"
-        },
-        {
-          "id": "davis",
-          "name": "Donald Davis",
-          "partyId": "1"
-        },
-        {
-          "id": "smith",
-          "name": "Hugo Smith",
-          "partyId": "1"
-        }
-      ],
-      "allowWriteIns": true
-    },
-    {
-      "id": "judicial-robert-demergue",
-      "districtId": "district-1",
-      "type": "yesno",
-      "section": "Hamilton Court of Appeals",
-      "title": "Retain Robert Demergue as Chief Justice?",
-      "description": "Shall Robert Demergue be retained as Chief Justice of the Hamilton Court of Appeals?"
-    },
-    {
-      "id": "judicial-elmer-hull",
-      "districtId": "district-2",
-      "type": "yesno",
-      "section": "Hamilton Court of Appeals",
-      "title": "Retain Elmer Hull as Associate Justice?",
-      "description": "Shall Elmer Hull be retained as Associate Justice of the Hamilton Court of Appeals?"
-    },
-    {
-      "id": "question-a",
-      "districtId": "district-1",
-      "type": "yesno",
-      "section": "State of Hamilton",
-      "shortTitle": "Question A",
-      "title": "Question A: Recovery of Property Damages",
-      "description": "Shall there be an amendment to the State constitution concerning recovery of damages relating to construction of real property improvements, and, in connection therewith, prohibiting laws that limit or impair a property owner's right to recover damages caused by a failure to construct an improvement in a good and workmanlike manner?"
-    },
-    {
-      "id": "question-b",
-      "districtId": "district-1",
-      "type": "yesno",
-      "section": "State of Hamilton",
-      "shortTitle": "Question B",
-      "title": "Question B: Separation of Powers",
-      "description": "Shall there be amendments to the State constitution intended to have the collective effect of ensuring the separation of governmental power among the three branches of state government: the legislative branch, the executive branch and the judicial branch?\n\na. Article III, Section 6 of the Constitution shall be amended to read as follows: \n\nSection 6. Holding of offices under other governments \n\nSenators and representatives not to hold other appointed offices under state government.\n\nNo person holding any office under the government of the United States, or of any other state or country, shall act as a general officer or as a member of the general assembly, unless at the time of taking such engagement that person shall have resigned the office under such government; and if any general officer, senator, representative, or judge shall, after election and engagement, accept any appointment under any other government, the office under this shall be immediately vacated; but this restriction shall not apply to any person appointed to take deposition or acknowledgement of deeds, or other legal instruments, by the authority of any other state or country.\n\nNo senator or representative shall, during the time for which he or she was elected, be appointed to any state office, board, commission or other state or quasi-public entity exercising executive power under the laws of this state, and no person holding any executive office or serving as a member of any board, commission or other state or quasi-public entity exercising executive power under the laws of this state shall be a member of the senate or the house of representatives during his or her continuance in such office.\n\nb. Article V of the Constitution shall be amended to read as follows: The powers of the government shall be distributed into three (3) separate and distinct departments: the legislative, the executive and the judicial.\n\nc. Article VI, Section 10 of the Constitution shall be deleted in its entirety.\n\nd. Article IX, Section 5 of the Constitution shall be amended to read as follows:\n\nSection 5. Powers of appointment.- The governor shall, by and with the advice and consent of the senate, appoint all officers of the state whose appointment is not herein otherwise provided for and all members of any board, commission or other state or quasi-public entity which exercises executive power under the laws of this state; but the general assembly may by law vest the appointment of such inferior officers, as they deem proper, in the governor, or within their respective departments in the other general officers, the judiciary or in the heads of departments."
-    },
-    {
-      "id": "question-c",
-      "districtId": "district-2",
-      "type": "yesno",
-      "section": "State of Hamilton",
-      "shortTitle": "Question C",
-      "title": "Question C: Limits to Damages for Non-Economic Loss",
-      "description": "Shall there be an amendment to the State constitution allowing the State legislature to enact laws limiting the amount of damages for non-economic loss that could be awarded for injury or death caused by a health care provider? \"Non-economic loss\" generally includes, but is not limited to, losses such as pain and suffering, inconvenience, mental anguish, loss of capacity for enjoyment of life, loss of consortium, and other losses the claimant is entitled to recover as damages under general law.\n\n This amendment will not in any way affect the recovery of damages for economic loss under State law. \"Economic loss\" generally includes, but is not limited to, monetary losses such as past and future medical expenses, loss of past and future earnings, loss of use of property, costs of repair or replacement, the economic value of domestic services, loss of employment or business opportunities. This amendment will not in any way affect the recovery of any additional damages known under State law as exemplary or punitive damages, which are damages allowed by law to punish a defendant and to deter persons from engaging in similar conduct in the future."
-    },
-    {
-      "id": "proposition-1",
-      "districtId": "district-1",
-      "type": "yesno",
-      "section": "State of Hamilton",
-      "shortTitle": "Proposition 1",
-      "title": "Proposition 1: Gambling in Franklin and Fromwit Counties",
-      "description": "Shall there be an amendment to the State constitution authorizing Franklin and Fromwit Counties to hold referenda on whether to authorize slot machines in existing, licensed pari-mutuel facilities (thoroughbred and harness racing, greyhound racing, and jai alai) that have conducted live racing or games in that county during each of the last two calendar years before effective date of this amendment? Requires implementing legislation."
-    },
-    {
-      "id": "measure-101",
-      "districtId": "district-2",
-      "type": "yesno",
-      "section": "Franklin County",
-      "shortTitle": "Measure 101",
-      "title": "Measure 101: College District",
-      "description": "To upgrade educational facilities at Diablo Valley, and Franklin, Colleges, and the San Brentwood center, and help prepare students for jobs and college transfer by modernizing classrooms and labs, building facilities for health, medical, science, and technology training, and implementing infrastructure improvements, shall the Franklin Community College District issue $450 million of bonds at legal interest rates with independent oversight, audits, and all funds spent on local sites?"
-    },
-    {
-      "id": "102",
-      "districtId": "district-1",
-      "type": "yesno",
-      "section": "Franklin County",
-      "shortTitle": "Measure 102",
-      "title": "Measure 102: Vehicle Abatement Program",
-      "description": "Should the Franklin County Vehicle Abatement Program and vehicle registration fees (one dollar per vehicle and an additional two dollars for certain commercial vehicles payable upon registration of a vehicle) be renewed for a ten-year term beginning July 1, 2021, for the abatement and removal of abandoned, wrecked, dismantled, or inoperative vehicles?"
-    },
-    {
-      "id": "measure-666",
-      "districtId": "district-1",
-      "partyId": "2",
-      "type": "yesno",
-      "section": "Franklin County",
-      "shortTitle": "Measure 666",
-      "title": "Measure 666: The Question No One Gets To",
-      "description": "This question has a partyId, but no ballot style with the corresponding districts has that partyId, so this question will never get selected by a ballot style. This completes test coverage."
-    },
-    {
-      "id": "primary-constitution-head-of-party",
-      "districtId": "7",
-      "partyId": "3",
-      "type": "candidate",
-      "section": "Franklin County",
-      "title": "Head of Constitution Party",
-      "seats": 1,
-      "candidates": [
-        {
-          "id": "alice",
-          "name": "Alice Jones",
-          "partyId": "3"
-        },
-        {
-          "id": "bob",
-          "name": "Bob Smith"
-        }
-      ]
-    }
-  ],
-  "precincts": [
-    {
-      "id": "23",
-      "name": "Center Springfield"
-    },
-    {
-      "id": "21",
-      "name": "North Springfield"
-    },
-    {
-      "id": "20",
-      "name": "South Springfield"
-    }
-  ],
-  "ballotStyles": [
-    {
-      "id": "12",
-      "precincts": ["23", "21"],
-      "districts": ["district-1", "district-2"]
-    },
-    {
-      "id": "5",
-      "precincts": ["21"],
-      "districts": ["district-1"]
-    },
-    {
-      "id": "7C",
-      "partyId": "3",
-      "precincts": ["20"],
-      "districts": ["7"]
-    }
-  ]
-}
 
-    
-    function doConfigure() {
-    fetch('/config', {
-    method: 'PUT',
-    body: JSON.stringify({ election }),
-    headers: {
-    'Content-Type': 'application/json'
-    }
-    }).then(function(response) {
-    return response.json()
-    }).then(function(responseJSON) {
-    alert(responseJSON)
-    })
+    async function scanFromFiles() {
+      const scanFilesInput = /** @type {HTMLInputElement} */ (document.getElementById(
+        'scan-files-input'
+      ))
+      const scanFilesButton = /** @type {HTMLButtonElement} */ (document.getElementById(
+        'scan-files-button'
+      ))
+      const scanFilesButtonText = scanFilesButton.textContent
+
+      scanFilesButton.textContent = 'Uploading…'
+      scanFilesButton.disabled = true
+
+      try {
+        const formData = new FormData()
+
+        for (const file of scanFilesInput.files) {
+          formData.append(
+            'files',
+            new Blob([await file.arrayBuffer()], { type: 'image/jpeg' }),
+            file.name
+          )
+        }
+
+        await fetch('/scan/scanFiles', {
+          method: 'POST',
+          body: formData,
+        })
+      } catch (error) {
+        console.error(error)
+        alert(error.message)
+      }
+
+      scanFilesButton.textContent = scanFilesButtonText
+      scanFilesButton.disabled = false
     }
   </script>
+
   <body>
     <h1>Test Page for Scan</h1>
-    
+
     <form>
-      <textarea id="result" style="font-family: monospace;" cols=80>
+      <textarea id="result" style="font-family: monospace;" cols="80" rows="10">
       </textarea>
     </form>
-
-    <button onclick="doConfigure()">Configure</button>
 
     <button onclick="doScan()">Scan</button>
 
     <form method="post" action="/scan/export">
-      <input type="submit" value="export">
+      <input type="submit" value="export" />
     </form>
+
+    <button id="scan-files-button" onclick="browseFileImagesToScan()">
+      Scan file(s)…
+    </button>
+    <input
+      id="scan-files-input"
+      type="file"
+      onchange="scanFromFiles()"
+      accept="image/jpeg"
+      multiple
+      style="opacity: 0;"
+    />
   </body>
+</html>

--- a/src/interpreter.test.ts
+++ b/src/interpreter.test.ts
@@ -13,8 +13,10 @@ const electionFixturesRoot = join(
 )
 
 test('reads QR codes from ballot images #1', async () => {
+  const filepath = join(sampleBallotImagesPath, 'sample-batch-1-ballot-1.jpg')
   const { qrcode } = await getBallotImageData(
-    join(sampleBallotImagesPath, 'sample-batch-1-ballot-1.jpg')
+    await readFile(filepath),
+    filepath
   )
 
   expect(qrcode).toEqual(
@@ -23,8 +25,10 @@ test('reads QR codes from ballot images #1', async () => {
 })
 
 test('reads QR codes from ballot images #2', async () => {
+  const filepath = join(sampleBallotImagesPath, 'sample-batch-1-ballot-2.jpg')
   const { qrcode } = await getBallotImageData(
-    join(sampleBallotImagesPath, 'sample-batch-1-ballot-2.jpg')
+    await readFile(filepath),
+    filepath
   )
 
   expect(qrcode).toEqual(
@@ -35,8 +39,9 @@ test('reads QR codes from ballot images #2', async () => {
 })
 
 test('does not find QR codes when there are none to find', async () => {
+  const filepath = join(sampleBallotImagesPath, 'not-a-ballot.jpg')
   await expect(
-    getBallotImageData(join(sampleBallotImagesPath, 'not-a-ballot.jpg'))
+    getBallotImageData(await readFile(filepath), filepath)
   ).rejects.toThrowError('no QR code found')
 })
 

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -150,6 +150,17 @@ test('POST /scan/scanBatch errors', async () => {
   expect(importer.doImport).toBeCalled()
 })
 
+test('POST /scan/scanFiles', async () => {
+  importerMock.importFile.mockResolvedValueOnce(undefined)
+  await request(app)
+    .post('/scan/scanFiles')
+    .attach('files', Buffer.of(), {
+      filename: 'ballot.jpg',
+      contentType: 'image/jpeg',
+    })
+    .expect(200, { status: 'ok' })
+})
+
 test('POST /scan/addManualBallot', async () => {
   importerMock.addManualBallot.mockResolvedValue(undefined)
   await request(app)

--- a/test/util/mocks.ts
+++ b/test/util/mocks.ts
@@ -16,6 +16,7 @@ export function makeMockImporter(): jest.Mocked<Importer> {
     configure: jest.fn(),
     doExport: jest.fn(),
     doImport: jest.fn(),
+    importFile: jest.fn(),
     doZero: jest.fn(),
     getStatus: jest.fn(),
     restoreConfig: jest.fn(),


### PR DESCRIPTION
In development it's sometimes useful to scan from arbitrary files on disk. This allows using the test page to do that. It also removes the "Configure" functionality since that doesn't work with HMPB config anyway.

![module-scan-scan-from-files](https://user-images.githubusercontent.com/1938/87727250-7702e180-c775-11ea-87cf-c58cf952abe7.gif)
