### PR TITLE
feat: track which ballots require adjudication

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -268,6 +268,16 @@ export function buildApp({ store, importer }: AppOptions): Application {
     }
   })
 
+  app.get('/scan/hmpb/review/next-ballot', async (_request, response) => {
+    const ballot = await store.getNextReviewBallot()
+
+    if (ballot) {
+      response.json(ballot)
+    } else {
+      response.status(404).end()
+    }
+  })
+
   app.post('/scan/zero', async (_request, response) => {
     await importer.doZero()
     response.json({ status: 'ok' })

--- a/src/types/ballot-review.ts
+++ b/src/types/ballot-review.ts
@@ -45,6 +45,6 @@ export interface CandidateContestOption {
 export interface YesNoContestOption {
   type: t.YesNoContest['type']
   id: Exclude<t.YesNoVote[0] | t.YesNoVote[1], undefined>
-  name: t.YesNoVote
+  name: string
   bounds: Rect
 }


### PR DESCRIPTION
This adds a db column to keep track of whether a ballot requires adjudication, and an endpoint to get the ballot information for the next ballot requiring adjudication.

Refs votingworks/vxmail#19