### PR TITLE
fix: ensure manually uploading the same ballot for testing twice works

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
 
       scanFilesButton.textContent = scanFilesButtonText
       scanFilesButton.disabled = false
-      scanFilesButton.value = null
+      scanFilesInput.value = null
     }
   </script>
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -105,7 +105,11 @@ export function buildApp({ store, importer }: AppOptions): Application {
 
           for (const file of files) {
             try {
-              await importer.importFile(batchId, file.originalname, file.buffer)
+              await importer.importFile(
+                batchId,
+                `batch-${batchId}-manual-upload-${file.originalname}`,
+                file.buffer
+              )
             } catch (error) {
               console.error(
                 `failed to import file ${file.originalname}: ${error.message}`


### PR DESCRIPTION
There were two bugs here:
- The test page only uploads a file when the input changes, and selecting the same file does not change it. I had tried to fix that, but did it incorrectly. Setting the file input value to `null` fixes it.
- We place imported files into a particular directory and name them based on the original filename. If you upload the same file twice, it would have the same destination file path. The unique constraint on `ballots#filename` in the database means the import fails. Now, we prepend the batch number to the filename to ensure it's unique.