### PR TITLE
fix: add a hash to imported filenames

### DIFF
--- a/src/interpreter.test.ts
+++ b/src/interpreter.test.ts
@@ -50,13 +50,15 @@ test('does not find QR codes when there are none to find', async () => {
 })
 
 test('extracts a CVR from votes encoded in a QR code', async () => {
+  const ballotImagePath = join(
+    sampleBallotImagesPath,
+    'sample-batch-1-ballot-1.jpg'
+  )
   expect(
     ((await new SummaryBallotInterpreter().interpretFile({
       election: electionSample,
-      ballotImagePath: join(
-        sampleBallotImagesPath,
-        'sample-batch-1-ballot-1.jpg'
-      ),
+      ballotImagePath,
+      ballotImageFile: await readFile(ballotImagePath),
     })) as InterpretedHmpbBallot).cvr
   ).toEqual(
     expect.objectContaining({
@@ -84,12 +86,14 @@ test('interprets marks on a HMPB', async () => {
     }
   }
 
+  const ballotImagePath = join(
+    electionFixturesRoot,
+    'filled-in-dual-language-p1.jpg'
+  )
   const cvr = ((await interpreter.interpretFile({
     election: hmpbElection,
-    ballotImagePath: join(
-      electionFixturesRoot,
-      'filled-in-dual-language-p1.jpg'
-    ),
+    ballotImagePath,
+    ballotImageFile: await readFile(ballotImagePath),
   })) as InterpretedHmpbBallot).cvr
 
   delete cvr?._ballotId
@@ -134,12 +138,14 @@ test('interprets marks on an upside-down HMPB', async () => {
     }
   }
 
+  const ballotImagePath = join(
+    electionFixturesRoot,
+    'filled-in-dual-language-p1-flipped.jpg'
+  )
   const cvr = ((await interpreter.interpretFile({
     election: hmpbElection,
-    ballotImagePath: join(
-      electionFixturesRoot,
-      'filled-in-dual-language-p1-flipped.jpg'
-    ),
+    ballotImagePath,
+    ballotImageFile: await readFile(ballotImagePath),
   })) as InterpretedHmpbBallot).cvr
 
   delete cvr?._ballotId
@@ -184,13 +190,15 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
     }
   }
 
+  const ballotImagePath = join(
+    electionFixturesRoot,
+    'filled-in-dual-language-p3.jpg'
+  )
   expect(
     (await interpreter.interpretFile({
       election: hmpbElection,
-      ballotImagePath: join(
-        electionFixturesRoot,
-        'filled-in-dual-language-p3.jpg'
-      ),
+      ballotImagePath,
+      ballotImageFile: await readFile(ballotImagePath),
     })) as UninterpretedHmpbBallot
   ).toMatchInlineSnapshot(`
     Object {

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -22,10 +22,8 @@ import {
 } from '@votingworks/hmpb-interpreter'
 import { detect as qrdetect } from '@votingworks/qrdetect'
 import makeDebug from 'debug'
-import { readFile as readFileCallback } from 'fs'
 import { decode as decodeJpeg } from 'jpeg-js'
 import { decode as quircDecode } from 'node-quirc'
-import { promisify } from 'util'
 import { CastVoteRecord } from './types'
 import { getMachineId } from './util/machineId'
 
@@ -34,7 +32,7 @@ const debug = makeDebug('module-scan:interpreter')
 export interface InterpretFileParams {
   readonly election: Election
   readonly ballotImagePath: string
-  readonly ballotImageFile?: Buffer
+  readonly ballotImageFile: Buffer
 }
 
 export interface MarkInfo {
@@ -87,8 +85,6 @@ export interface Interpreter {
   ): Promise<InterpretedBallot | undefined>
   setTestMode(testMode: boolean): void
 }
-
-const readFile = promisify(readFileCallback)
 
 interface InterpretBallotStringParams {
   readonly election: Election
@@ -226,7 +222,7 @@ export default class SummaryBallotInterpreter implements Interpreter {
 
     try {
       ballotImageData = await getBallotImageData(
-        ballotImageFile ?? (await readFile(ballotImagePath)),
+        ballotImageFile,
         ballotImagePath
       )
     } catch (error) {


### PR DESCRIPTION
This is just a defensive move that makes it relatively easy to see, on audit, if two files are the same. We'll want to expand this later if we think it's a good thing to do.