### PR TITLE
test: fix hang on finish

### DIFF
--- a/src/importer.test.ts
+++ b/src/importer.test.ts
@@ -123,6 +123,7 @@ test('setTestMode zeroes and sets test mode on the interpreter', async () => {
 
   await importer.setTestMode(true)
   expect((await importer.getStatus()).batches).toHaveLength(0)
+  await importer.unconfigure()
 })
 
 test('restoreConfig reads config data from the store', async () => {
@@ -183,6 +184,7 @@ test('restoreConfig reads config data from the store', async () => {
   expect(importer.configure).toHaveBeenCalledWith(election)
   expect(interpreter.addHmpbTemplate).toHaveBeenCalledTimes(2)
   expect(interpreter.setTestMode).toHaveBeenCalledWith(true)
+  await importer.unconfigure()
 })
 
 test('cannot add HMPB templates before configuring an election', async () => {


### PR DESCRIPTION
The tests have been hanging on finish for a while while jest waits for the child processes running the tests after their last test completes. It results in this warning:

> Jest did not exit one second after the test run has completed.
>
> This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.

There were two causes:
- a file watcher that wasn't closed because there wasn't a matching `Importer#unconfigure` for every `Importer#configure`, leaving a file watcher in place
- a `setTimeout` used to finish the current batch had yet to fire

I fixed the first one by ensuring `unconfigure` was called properly. The second I fixed by clearing timeouts on unconfigure.