### PR TITLE
feat: allow waiting for imports

### DIFF
--- a/src/endToEndHmpb.test.ts
+++ b/src/endToEndHmpb.test.ts
@@ -172,6 +172,8 @@ test('going through the whole process works', async () => {
       }
     `)
   }
+
+  await importer.waitForImports()
 })
 
 test('failed scan with QR code can be adjudicated and exported', async () => {
@@ -267,4 +269,6 @@ test('failed scan with QR code can be adjudicated and exported', async () => {
       }
     `)
   }
+
+  await importer.waitForImports()
 })

--- a/test/util/mocks.ts
+++ b/test/util/mocks.ts
@@ -17,6 +17,7 @@ export function makeMockImporter(): jest.Mocked<Importer> {
     doExport: jest.fn(),
     doImport: jest.fn(),
     importFile: jest.fn(),
+    waitForImports: jest.fn(),
     doZero: jest.fn(),
     getStatus: jest.fn(),
     restoreConfig: jest.fn(),


### PR DESCRIPTION
This can be used to make the tests run more predictably, and could potentially be used by an HTTP endpoint.