### PR TITLE
feat: detect more adjudication conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@types/sharp": "^0.25.1",
     "@votingworks/ballot-encoder": "^2.0.1",
-    "@votingworks/hmpb-interpreter": "^4.0.0",
+    "@votingworks/hmpb-interpreter": "^4.0.1",
     "@votingworks/qrdetect": "^1.0.1",
     "busboy": "^0.3.1",
     "canvas": "^2.6.1",

--- a/src/types/ballot-review.ts
+++ b/src/types/ballot-review.ts
@@ -61,6 +61,7 @@ export interface CandidateContestOption {
   type: t.CandidateContest['type']
   id: t.CandidateContest['id']
   name: t.Candidate['name']
+  isWriteIn: boolean
 }
 
 export interface YesNoContestOption {

--- a/src/util/allContestOptions.ts
+++ b/src/util/allContestOptions.ts
@@ -1,0 +1,44 @@
+import { CandidateContest, YesNoContest } from '@votingworks/ballot-encoder'
+import { ContestOption } from '../types'
+
+type AnyContest = CandidateContest | YesNoContest
+
+/**
+ * Enumerates all contest options in the order they would appear on a HMPB.
+ */
+export default function* allContestOptions(
+  contest: AnyContest
+): Generator<ContestOption> {
+  if (contest.type === 'candidate') {
+    for (const candidate of contest.candidates) {
+      yield {
+        type: 'candidate',
+        id: candidate.id,
+        name: candidate.name,
+        isWriteIn: false,
+      }
+    }
+
+    if (contest.allowWriteIns) {
+      for (let i = 0; i < contest.seats; i++) {
+        yield {
+          type: 'candidate',
+          id: `__write-in-${i}`,
+          name: 'Write-In',
+          isWriteIn: true,
+        }
+      }
+    }
+  } else {
+    yield {
+      type: 'yesno',
+      id: 'yes',
+      name: 'Yes',
+    }
+    yield {
+      type: 'yesno',
+      id: 'no',
+      name: 'No',
+    }
+  }
+}

--- a/src/util/ballotAdjudicationReasons.test.ts
+++ b/src/util/ballotAdjudicationReasons.test.ts
@@ -1,0 +1,229 @@
+import ballotAdjudicationReasons, {
+  AdjudicationReasonType,
+  adjudicationReasonDescription,
+} from './ballotAdjudicationReasons'
+import { MarkStatus } from '../types/ballot-review'
+import election from '../../test/fixtures/2020-choctaw/election'
+import { CandidateContest, YesNoContest } from '@votingworks/ballot-encoder'
+
+const president = election.contests.find(
+  ({ id }) => id === '1'
+) as CandidateContest
+const senator = election.contests.find(
+  ({ id }) => id === '2'
+) as CandidateContest
+const [presidentialCandidate1, presidentialCandidate2] = president.candidates
+const [
+  senatorialCandidate1,
+  senatorialCandidate2,
+  senatorialCandidate3,
+] = senator.candidates
+const initiative65 = election.contests.find(
+  ({ id }) => id === 'initiative-65'
+) as YesNoContest
+
+test('an uninterpretable ballot', () => {
+  expect([
+    ...ballotAdjudicationReasons(undefined, {
+      optionMarkStatus: () => MarkStatus.Unmarked,
+    }),
+  ]).toEqual([{ type: AdjudicationReasonType.UninterpretableBallot }])
+})
+
+test('a ballot with no adjudication reasons', () => {
+  expect([
+    ...ballotAdjudicationReasons([president], {
+      optionMarkStatus: (contestId, optionId) =>
+        // mark the expected number of options
+        contestId === president.id && optionId === presidentialCandidate1.id
+          ? MarkStatus.Marked
+          : MarkStatus.Unmarked,
+    }),
+  ]).toEqual([])
+})
+
+test('a ballot with marginal marks', () => {
+  const reasons = [
+    ...ballotAdjudicationReasons([president], {
+      optionMarkStatus: (contestId, optionId) => {
+        if (contestId === president.id) {
+          switch (optionId) {
+            case presidentialCandidate1.id:
+              return MarkStatus.Marked
+            case presidentialCandidate2.id:
+              return MarkStatus.Marginal
+          }
+        }
+
+        return MarkStatus.Unmarked
+      },
+    }),
+  ]
+
+  expect(reasons).toEqual([
+    {
+      type: AdjudicationReasonType.MarginalMark,
+      contestId: president.id,
+      optionId: presidentialCandidate2.id,
+    },
+  ])
+
+  expect(reasons.map(adjudicationReasonDescription)).toMatchInlineSnapshot(`
+    Array [
+      "Contest '1' has a marginal mark for option '2'.",
+    ]
+  `)
+})
+
+test('a ballot with no marks', () => {
+  const reasons = [
+    ...ballotAdjudicationReasons([president], {
+      optionMarkStatus: () => MarkStatus.Unmarked,
+    }),
+  ]
+
+  expect(reasons).toEqual([
+    {
+      type: AdjudicationReasonType.Undervote,
+      contestId: president.id,
+      optionIds: [],
+      expected: 1,
+    },
+  ])
+
+  expect(reasons.map(adjudicationReasonDescription)).toMatchInlineSnapshot(`
+    Array [
+      "Contest '1' is undervoted, expected 1 but got none.",
+    ]
+  `)
+})
+
+test('a ballot with too many marks', () => {
+  const reasons = [
+    ...ballotAdjudicationReasons([president], {
+      optionMarkStatus: (contestId, optionId) => {
+        if (contestId === president.id) {
+          switch (optionId) {
+            case presidentialCandidate1.id:
+            case presidentialCandidate2.id:
+              return MarkStatus.Marked
+          }
+        }
+
+        return MarkStatus.Unmarked
+      },
+    }),
+  ]
+
+  expect(reasons).toEqual([
+    {
+      type: AdjudicationReasonType.Overvote,
+      contestId: president.id,
+      optionIds: [presidentialCandidate1.id, presidentialCandidate2.id],
+      expected: 1,
+    },
+  ])
+
+  expect(reasons.map(adjudicationReasonDescription)).toMatchInlineSnapshot(`
+    Array [
+      "Contest '1' is overvoted, expected 1 but got 2: '1', '2'.",
+    ]
+  `)
+})
+
+test('multiple contests with issues', () => {
+  const reasons = [
+    ...ballotAdjudicationReasons([president, senator], {
+      optionMarkStatus: (contestId, optionId) =>
+        // first presidential candidate marginally marked
+        contestId === president.id && optionId === presidentialCandidate1.id
+          ? MarkStatus.Marginal
+          : // all senatorial options marked
+          contestId === senator.id
+          ? MarkStatus.Marked
+          : // everything else unmarked
+            MarkStatus.Unmarked,
+    }),
+  ]
+
+  expect(reasons).toEqual([
+    {
+      type: AdjudicationReasonType.MarginalMark,
+      contestId: president.id,
+      optionId: presidentialCandidate1.id,
+    },
+    {
+      type: AdjudicationReasonType.Undervote,
+      contestId: president.id,
+      optionIds: [],
+      expected: 1,
+    },
+    {
+      type: AdjudicationReasonType.WriteIn,
+      contestId: senator.id,
+      optionId: '__write-in-0',
+    },
+    {
+      type: AdjudicationReasonType.Overvote,
+      contestId: senator.id,
+      optionIds: [
+        senatorialCandidate1.id,
+        senatorialCandidate2.id,
+        senatorialCandidate3.id,
+        '__write-in-0',
+      ],
+      expected: 1,
+    },
+  ])
+
+  expect(reasons.map(adjudicationReasonDescription)).toMatchInlineSnapshot(`
+    Array [
+      "Contest '1' has a marginal mark for option '1'.",
+      "Contest '1' is undervoted, expected 1 but got none.",
+      "Contest '2' has a write-in.",
+      "Contest '2' is overvoted, expected 1 but got 4: '21', '22', '23', '__write-in-0'.",
+    ]
+  `)
+})
+
+test('yesno contest overvotes', () => {
+  const reasons = [
+    ...ballotAdjudicationReasons([initiative65], {
+      optionMarkStatus: () => MarkStatus.Marked,
+    }),
+  ]
+
+  expect(reasons).toEqual([
+    {
+      type: AdjudicationReasonType.Overvote,
+      contestId: initiative65.id,
+      optionIds: ['yes', 'no'],
+      expected: 1,
+    },
+  ])
+
+  expect(reasons.map(adjudicationReasonDescription)).toMatchInlineSnapshot(`
+    Array [
+      "Contest 'initiative-65' is overvoted, expected 1 but got 2: 'yes', 'no'.",
+    ]
+  `)
+})
+
+test('a ballot with a just a write-in', () => {
+  const reasons = [
+    ...ballotAdjudicationReasons([president], {
+      optionMarkStatus: (contestId, optionId) =>
+        contestId === president.id && optionId === '__write-in-0'
+          ? MarkStatus.Marked
+          : MarkStatus.Unmarked,
+    }),
+  ]
+
+  expect(reasons).toEqual([
+    {
+      type: AdjudicationReasonType.WriteIn,
+      contestId: president.id,
+      optionId: '__write-in-0',
+    },
+  ])
+})

--- a/src/util/ballotAdjudicationReasons.ts
+++ b/src/util/ballotAdjudicationReasons.ts
@@ -1,0 +1,154 @@
+import { Contest, Contests } from '@votingworks/ballot-encoder'
+import { ContestOption, MarkStatus } from '../types'
+import allContestOptions from './allContestOptions'
+
+export enum AdjudicationReasonType {
+  UninterpretableBallot = 'UninterpretableBallot',
+  MarginalMark = 'MarginalMark',
+  Overvote = 'Overvote',
+  Undervote = 'Undervote',
+  WriteIn = 'WriteIn',
+}
+
+export type AdjudicationReason =
+  | UninterpretableBallotAdjudicationReason
+  | MarginalMarkAdjudicationReason
+  | OvervoteAdjudicationReason
+  | UndervoteAdjudicationReason
+  | WriteInAdjudicationReason
+
+export interface UninterpretableBallotAdjudicationReason {
+  type: AdjudicationReasonType.UninterpretableBallot
+}
+
+export interface MarginalMarkAdjudicationReason {
+  type: AdjudicationReasonType.MarginalMark
+  contestId: Contest['id']
+  optionId: ContestOption['id']
+}
+
+export interface OvervoteAdjudicationReason {
+  type: AdjudicationReasonType.Overvote
+  contestId: Contest['id']
+  optionIds: readonly ContestOption['id'][]
+  expected: number
+}
+
+export interface UndervoteAdjudicationReason {
+  type: AdjudicationReasonType.Undervote
+  contestId: Contest['id']
+  optionIds: readonly ContestOption['id'][]
+  expected: number
+}
+
+export interface WriteInAdjudicationReason {
+  type: AdjudicationReasonType.WriteIn
+  contestId: Contest['id']
+  optionId: ContestOption['id']
+}
+
+export interface Options {
+  optionMarkStatus: (
+    contestId: Contest['id'],
+    optionId: ContestOption['id']
+  ) => MarkStatus
+}
+
+/**
+ * Enumerates all the reasons a series of contests might need adjudication.
+ * Callers must provide a function that can get the mark status for any contest
+ * option in the contests given.
+ */
+export default function* ballotAdjudicationReasons(
+  contests: Contests | undefined,
+  { optionMarkStatus }: Options
+): Generator<AdjudicationReason> {
+  if (!contests) {
+    yield {
+      type: AdjudicationReasonType.UninterpretableBallot,
+    }
+  } else {
+    for (const contest of contests) {
+      const selectedOptionIds: ContestOption['id'][] = []
+
+      for (const option of allContestOptions(contest)) {
+        switch (optionMarkStatus(contest.id, option.id)) {
+          case MarkStatus.Marginal:
+            yield {
+              type: AdjudicationReasonType.MarginalMark,
+              contestId: contest.id,
+              optionId: option.id,
+            }
+            break
+
+          case MarkStatus.Marked:
+            selectedOptionIds.push(option.id)
+
+            if (option.type === 'candidate' && option.isWriteIn) {
+              yield {
+                type: AdjudicationReasonType.WriteIn,
+                contestId: contest.id,
+                optionId: option.id,
+              }
+            }
+        }
+      }
+
+      const expectedSelectionCount =
+        contest.type === 'candidate' ? contest.seats : 1 // yes or no
+
+      if (selectedOptionIds.length < expectedSelectionCount) {
+        yield {
+          type: AdjudicationReasonType.Undervote,
+          contestId: contest.id,
+          optionIds: selectedOptionIds,
+          expected: expectedSelectionCount,
+        }
+      } else if (selectedOptionIds.length > expectedSelectionCount) {
+        yield {
+          type: AdjudicationReasonType.Overvote,
+          contestId: contest.id,
+          optionIds: selectedOptionIds,
+          expected: expectedSelectionCount,
+        }
+      }
+    }
+  }
+}
+
+export function adjudicationReasonDescription(
+  reason: AdjudicationReason
+): string {
+  switch (reason.type) {
+    case AdjudicationReasonType.UninterpretableBallot:
+      return 'The ballot could not be interpreted at all, possibly due to a bad scan.'
+
+    case AdjudicationReasonType.MarginalMark:
+      return `Contest '${reason.contestId}' has a marginal mark for option '${reason.optionId}'.`
+
+    case AdjudicationReasonType.Overvote:
+      return `Contest '${reason.contestId}' is overvoted, expected ${
+        reason.expected
+      } but got ${
+        reason.optionIds.length
+          ? `${reason.optionIds.length}: ${reason.optionIds
+              .map((id) => `'${id}'`)
+              .join(', ')}`
+          : 'none'
+      }.`
+
+    case AdjudicationReasonType.Undervote:
+      return `Contest '${reason.contestId}' is undervoted, expected ${
+        reason.expected
+      } but got ${
+        reason.optionIds.length
+          ? `${reason.optionIds.length}: ${reason.optionIds
+              .map((id) => `'${id}'`)
+              .join(', ')}`
+          : 'none'
+      }.`
+
+    case AdjudicationReasonType.WriteIn:
+      return `Contest '${reason.contestId}' has a write-in.`
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -975,10 +975,10 @@
     "@antongolub/iso8601" "^1.2.1"
     zod "^1.7.1"
 
-"@votingworks/hmpb-interpreter@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@votingworks/hmpb-interpreter/-/hmpb-interpreter-4.0.0.tgz#da5c0146d71afa4fe235dc305e6f5598e5d80dce"
-  integrity sha512-hyn7XL9ir2snm67Y7AXLxNnLB6imaM3vObIvrHucFV5/+EKoDkJCp856LjL1lh20LEfzSw/AHScbOO4Y9W7NpQ==
+"@votingworks/hmpb-interpreter@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@votingworks/hmpb-interpreter/-/hmpb-interpreter-4.0.1.tgz#ff167498eedce66d529b6a7a515200228cbbdc97"
+  integrity sha512-bx1AgjRvLo7FqauZkF5LK63KmLLE9afm4KMImCn8Y661kzlok50Eivde1MnYifw21er2PFt24QcFPIFV+shJTw==
   dependencies:
     "@votingworks/ballot-encoder" "^2.0.0"
     canvas "^2.6.1"


### PR DESCRIPTION
In addition to marginal marks, this commit adds support for detecting overvote, undervote, and write-in conditions. It currently does not act on them except to log the adjudication reason and that it was ignored. These will not be ignored in the future, and will be configurable by the end user at some point.

For example, uploading this file:

![incorrect-undervote-p1 copy](https://user-images.githubusercontent.com/1938/89475092-265f2280-d73c-11ea-9a7d-110185ae9a66.png)

Logs this:

```
  module-scan:store Adjudication reason ignored by configuration: Contest '4' has a write-in. +923ms
  module-scan:store Adjudication reason ignored by configuration: Contest 'initiative-65' is overvoted, expected 1 but got 2: 'yes', 'no'. +0ms
```