### PR TITLE
race condition in ballot addition that could result in wrong return value for ballot ID

### DIFF
--- a/src/endToEnd.test.ts
+++ b/src/endToEnd.test.ts
@@ -20,7 +20,7 @@ const sampleBallotImagesPath = path.join(
 )
 
 // we need longer to make chokidar work
-jest.setTimeout(10000)
+jest.setTimeout(20000)
 
 jest.mock('./exec', () => ({
   __esModule: true,


### PR DESCRIPTION
address race condition in ballot creation that, when two ballots are added almost simultaneously, could return the same ballot ID in both cases. This was not likely to be a big problem because the two rows are still inserted, but now that I'm trying to use the return value, it matters.