### PR TITLE
Detect blank ballots as a possible adjudication reason

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@types/sharp": "^0.25.1",
-    "@votingworks/ballot-encoder": "^2.0.1",
+    "@votingworks/ballot-encoder": "^2.2.0",
     "@votingworks/hmpb-interpreter": "^4.0.1",
     "@votingworks/qrdetect": "^1.0.1",
     "busboy": "^0.3.1",

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -9,7 +9,7 @@ import * as fsExtra from 'fs-extra'
 import { Election } from '@votingworks/ballot-encoder'
 import { BallotPageLayout } from '@votingworks/hmpb-interpreter'
 
-import { BatchInfo, BallotMetadata, AdjudicationStatus } from './types'
+import { BallotMetadata, ScanStatus } from './types'
 import Store from './store'
 import DefaultInterpreter, {
   Interpreter,
@@ -52,7 +52,7 @@ export interface Importer {
    */
   waitForImports(): Promise<void>
 
-  getStatus(): Promise<{ batches: BatchInfo[]; electionHash?: string }>
+  getStatus(): Promise<ScanStatus>
   restoreConfig(): Promise<void>
   setTestMode(testMode: boolean): Promise<void>
   unconfigure(): Promise<void>
@@ -472,11 +472,7 @@ export default class SystemImporter implements Importer {
   /**
    * Get the imported batches and current election info, if any.
    */
-  public async getStatus(): Promise<{
-    electionHash?: string
-    batches: BatchInfo[]
-    adjudication: AdjudicationStatus
-  }> {
+  public async getStatus(): Promise<ScanStatus> {
     const election = await this.store.getElection()
     const batches = await this.store.batchStatus()
     const adjudication = await this.store.adjudicationStatus()

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -15,6 +15,7 @@ import { buildApp, start } from './server'
 import Store from './store'
 import { MarkStatus } from './types/ballot-review'
 import EMPTY_IMAGE from '../test/fixtures/emptyImage'
+import { ScanStatus } from './types'
 
 jest.mock('./importer')
 
@@ -60,8 +61,9 @@ beforeEach(async () => {
 })
 
 test('GET /scan/status', async () => {
-  const status = {
+  const status: ScanStatus = {
     batches: [],
+    adjudication: { remaining: 0, adjudicated: 0 },
   }
   importerMock.getStatus.mockResolvedValue(status)
   await request(app)

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,7 +2,12 @@
 // The durable datastore for CVRs and configuration info.
 //
 
-import { Contests, Election, getBallotStyle } from '@votingworks/ballot-encoder'
+import {
+  Contests,
+  Election,
+  getBallotStyle,
+  AdjudicationReason,
+} from '@votingworks/ballot-encoder'
 import {
   BallotLocales,
   BallotMark,
@@ -34,7 +39,6 @@ import {
 import allContestOptions from './util/allContestOptions'
 import ballotAdjudicationReasons, {
   adjudicationReasonDescription,
-  AdjudicationReasonType,
 } from './util/ballotAdjudicationReasons'
 import getBallotPageContests from './util/getBallotPageContests'
 import { changesFromMarks, changesToCVR, mergeChanges } from './util/marks'
@@ -400,8 +404,8 @@ export default class Store {
 
         // For now, only consider these reasons as requiring adjudication.
         const enabledAdjudicationReasons = [
-          AdjudicationReasonType.UninterpretableBallot,
-          AdjudicationReasonType.MarginalMark,
+          AdjudicationReason.UninterpretableBallot,
+          AdjudicationReason.MarginalMark,
         ]
 
         for (const reason of adjudicationReasons) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -402,8 +402,8 @@ export default class Store {
           }),
         ]
 
-        // For now, only consider these reasons as requiring adjudication.
-        const enabledAdjudicationReasons = [
+        const election = await this.getElection()
+        const enabledAdjudicationReasons = election?.adjudicationReasons ?? [
           AdjudicationReason.UninterpretableBallot,
           AdjudicationReason.MarginalMark,
         ]

--- a/src/store.ts
+++ b/src/store.ts
@@ -55,6 +55,13 @@ interface HmpbTemplatesColumns {
   layoutsJSON: string
 }
 
+export enum ConfigKey {
+  Election = 'election',
+  TestMode = 'testMode',
+}
+
+export const ALLOWED_CONFIG_KEYS: readonly string[] = Object.values(ConfigKey)
+
 /**
  * Manages a data store for imported ballot image batches and cast vote records
  * interpreted by reading the ballots.
@@ -262,37 +269,37 @@ export default class Store {
    * Gets the current election definition.
    */
   public async getElection(): Promise<Election | undefined> {
-    return await this.getConfig('election')
+    return await this.getConfig(ConfigKey.Election)
   }
 
   /**
    * Sets the current election definition.
    */
   public async setElection(election?: Election): Promise<void> {
-    await this.setConfig('election', election)
+    await this.setConfig(ConfigKey.Election, election)
   }
 
   /**
    * Gets the current test mode setting value.
    */
   public async getTestMode(): Promise<boolean> {
-    return await this.getConfig('testMode', false)
+    return await this.getConfig(ConfigKey.TestMode, false)
   }
 
   /**
    * Sets the current test mode setting value.
    */
   public async setTestMode(testMode: boolean): Promise<void> {
-    await this.setConfig('testMode', testMode)
+    await this.setConfig(ConfigKey.TestMode, testMode)
   }
 
   /**
    * Gets a config value by key.
    */
-  private async getConfig<T>(key: string): Promise<T | undefined>
-  private async getConfig<T>(key: string, defaultValue: T): Promise<T>
+  private async getConfig<T>(key: ConfigKey): Promise<T | undefined>
+  private async getConfig<T>(key: ConfigKey, defaultValue: T): Promise<T>
   private async getConfig<T>(
-    key: string,
+    key: ConfigKey,
     defaultValue?: T
   ): Promise<T | undefined> {
     debug('get config %s', key)
@@ -312,7 +319,7 @@ export default class Store {
   /**
    * Sets the current election definition.
    */
-  private async setConfig<T>(key: string, value?: T): Promise<void> {
+  private async setConfig<T>(key: ConfigKey, value?: T): Promise<void> {
     debug('set config %s=%O', key, value)
     if (typeof value === 'undefined') {
       await this.dbRunAsync('delete from configs where key = ?', key)

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,12 @@ export interface CastVoteRecord
   _locales?: BallotLocales
 }
 
+export interface ScanStatus {
+  electionHash?: string
+  batches: BatchInfo[]
+  adjudication: AdjudicationStatus
+}
+
 export interface BatchInfo {
   id: number
   startedAt: Date

--- a/src/util/ballotAdjudicationReasons.test.ts
+++ b/src/util/ballotAdjudicationReasons.test.ts
@@ -1,10 +1,13 @@
+import {
+  AdjudicationReason,
+  CandidateContest,
+  YesNoContest,
+} from '@votingworks/ballot-encoder'
+import election from '../../test/fixtures/2020-choctaw/election'
+import { MarkStatus } from '../types/ballot-review'
 import ballotAdjudicationReasons, {
-  AdjudicationReasonType,
   adjudicationReasonDescription,
 } from './ballotAdjudicationReasons'
-import { MarkStatus } from '../types/ballot-review'
-import election from '../../test/fixtures/2020-choctaw/election'
-import { CandidateContest, YesNoContest } from '@votingworks/ballot-encoder'
 
 const president = election.contests.find(
   ({ id }) => id === '1'
@@ -27,7 +30,7 @@ test('an uninterpretable ballot', () => {
     ...ballotAdjudicationReasons(undefined, {
       optionMarkStatus: () => MarkStatus.Unmarked,
     }),
-  ]).toEqual([{ type: AdjudicationReasonType.UninterpretableBallot }])
+  ]).toEqual([{ type: AdjudicationReason.UninterpretableBallot }])
 })
 
 test('a ballot with no adjudication reasons', () => {
@@ -62,7 +65,7 @@ test('a ballot with marginal marks', () => {
 
   expect(reasons).toEqual([
     {
-      type: AdjudicationReasonType.MarginalMark,
+      type: AdjudicationReason.MarginalMark,
       contestId: president.id,
       optionId: presidentialCandidate2.id,
     },
@@ -84,16 +87,20 @@ test('a ballot with no marks', () => {
 
   expect(reasons).toEqual([
     {
-      type: AdjudicationReasonType.Undervote,
+      type: AdjudicationReason.Undervote,
       contestId: president.id,
       optionIds: [],
       expected: 1,
+    },
+    {
+      type: AdjudicationReason.BlankBallot,
     },
   ])
 
   expect(reasons.map(adjudicationReasonDescription)).toMatchInlineSnapshot(`
     Array [
       "Contest '1' is undervoted, expected 1 but got none.",
+      "Ballot has no votes.",
     ]
   `)
 })
@@ -117,7 +124,7 @@ test('a ballot with too many marks', () => {
 
   expect(reasons).toEqual([
     {
-      type: AdjudicationReasonType.Overvote,
+      type: AdjudicationReason.Overvote,
       contestId: president.id,
       optionIds: [presidentialCandidate1.id, presidentialCandidate2.id],
       expected: 1,
@@ -148,23 +155,23 @@ test('multiple contests with issues', () => {
 
   expect(reasons).toEqual([
     {
-      type: AdjudicationReasonType.MarginalMark,
+      type: AdjudicationReason.MarginalMark,
       contestId: president.id,
       optionId: presidentialCandidate1.id,
     },
     {
-      type: AdjudicationReasonType.Undervote,
+      type: AdjudicationReason.Undervote,
       contestId: president.id,
       optionIds: [],
       expected: 1,
     },
     {
-      type: AdjudicationReasonType.WriteIn,
+      type: AdjudicationReason.WriteIn,
       contestId: senator.id,
       optionId: '__write-in-0',
     },
     {
-      type: AdjudicationReasonType.Overvote,
+      type: AdjudicationReason.Overvote,
       contestId: senator.id,
       optionIds: [
         senatorialCandidate1.id,
@@ -195,7 +202,7 @@ test('yesno contest overvotes', () => {
 
   expect(reasons).toEqual([
     {
-      type: AdjudicationReasonType.Overvote,
+      type: AdjudicationReason.Overvote,
       contestId: initiative65.id,
       optionIds: ['yes', 'no'],
       expected: 1,
@@ -221,7 +228,7 @@ test('a ballot with a just a write-in', () => {
 
   expect(reasons).toEqual([
     {
-      type: AdjudicationReasonType.WriteIn,
+      type: AdjudicationReason.WriteIn,
       contestId: president.id,
       optionId: '__write-in-0',
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -967,10 +967,10 @@
     "@antongolub/iso8601" "^1.2.1"
     zod "^1.7.1"
 
-"@votingworks/ballot-encoder@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@votingworks/ballot-encoder/-/ballot-encoder-2.0.1.tgz#e056043987b9ef45233b22b496a2133b4daf40e4"
-  integrity sha512-qSNvWbspuoI+PMU1zK1LcImk2laOXT76rMSXUPFAMWi7XbcajzMU65fFHv/m8A9g130QxNzefS3pTXaaFwtkbQ==
+"@votingworks/ballot-encoder@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@votingworks/ballot-encoder/-/ballot-encoder-2.2.0.tgz#92400d3165e87538d324c678cd7d63be47a23fc3"
+  integrity sha512-o0nxhQkbNXupGH8Mh3lfyugz33luhKPvmow1gfKcVzoSTJP7fw2/C/gmZnrSkqFiZisEsbW223FyUbgiaR7+UQ==
   dependencies:
     "@antongolub/iso8601" "^1.2.1"
     zod "^1.7.1"


### PR DESCRIPTION
This also allows an election config to specify which adjudication reasons to use.