### PR TITLE
perf: do not re-encode BMD ballot scans

### DIFF
--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -58,7 +58,6 @@ export interface ManualBallot {
 
 export interface InterpretedBmdBallot {
   type: 'InterpretedBmdBallot'
-  normalizedImage: ImageData
   cvr: CastVoteRecord
 }
 
@@ -309,7 +308,7 @@ export default class SummaryBallotInterpreter implements Interpreter {
 
   private async interpretBMDFile(
     election: Election,
-    { qrcode, image }: BallotImageData
+    { qrcode }: BallotImageData
   ): Promise<InterpretedBmdBallot | undefined> {
     if (typeof detect(qrcode) === 'undefined') {
       return
@@ -318,7 +317,7 @@ export default class SummaryBallotInterpreter implements Interpreter {
     const cvr = interpretBallotData({ election, encodedBallot: qrcode })
 
     if (cvr) {
-      return { type: 'InterpretedBmdBallot', cvr, normalizedImage: image }
+      return { type: 'InterpretedBmdBallot', cvr }
     }
   }
 


### PR DESCRIPTION
There's no reason at the moment to have a normalized image for BMD ballot scans. This saves about 500-800ms per BMD ballot scanned.