### PR TITLE
fix: add UTC suffix to timestamps

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -811,8 +811,8 @@ export default class Store {
     return this.dbAllAsync(`
       select
         batches.id as id,
-        started_at,
-        ended_at,
+        started_at || 'Z' as startedAt,
+        (case when ended_at is null then ended_at else ended_at || 'Z' end) as endedAt,
         count(*) as count
       from
         ballots,


### PR DESCRIPTION
The sqlite `CURRENT_TIMESTAMP` value is a string in ISO 8601 format, but without the timezone.