### PR TITLE
chore: add Make target for dumping debug data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ hmpb-templates
 *.log
 coverage/
 .DS_Store
+debug-dump*.zip

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PLATFORM := $(shell uname)
+TIMESTAMP := $(shell date --iso-8601=seconds --utc | sed 's/+.*$\//g' | tr ':' '-')
 
 # a phony dependency that can be used as a dependency to force builds
 FORCE:
@@ -17,3 +18,9 @@ build: FORCE
 
 run:
 	yarn start
+
+debug-dump:
+	git rev-parse HEAD > REVISION
+	zip -r debug-dump-$(TIMESTAMP).zip REVISION tmp cvrs.db
+	rm REVISION
+	@echo "Debug info dumped to debug-dump-$(TIMESTAMP).zip"


### PR DESCRIPTION
Includes everything in the `tmp` directory where the images are stored, the database file, and the git revision.