### PR TITLE
fix: re-create database if schema has changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
-cvrs.db
+*.db
+*.db.digest
 tmp
 !tmp/.gitkeep
 hmpb-templates

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,6 @@ run:
 
 debug-dump:
 	git rev-parse HEAD > REVISION
-	zip -r debug-dump-$(TIMESTAMP).zip REVISION tmp *.db
+	zip -r debug-dump-$(TIMESTAMP).zip REVISION tmp *.db *.db.digest
 	rm REVISION
 	@echo "Debug info dumped to debug-dump-$(TIMESTAMP).zip"

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,6 @@ run:
 
 debug-dump:
 	git rev-parse HEAD > REVISION
-	zip -r debug-dump-$(TIMESTAMP).zip REVISION tmp cvrs.db
+	zip -r debug-dump-$(TIMESTAMP).zip REVISION tmp *.db
 	rm REVISION
 	@echo "Debug info dumped to debug-dump-$(TIMESTAMP).zip"

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,50 @@
+-- enforce foreign key constraints
+pragma foreign_keys = 1;
+
+create table batches (
+  id varchar(36) primary key,
+  started_at datetime default current_timestamp not null,
+  ended_at datetime
+);
+
+create table ballots (
+  id varchar(36) primary key,
+  batch_id varchar(36),
+  original_filename text unique,
+  normalized_filename text unique,
+  marks_json text,
+  cvr_json text,
+  metadata_json text,
+  adjudication_json text,
+  adjudication_info_json text,
+  requires_adjudication boolean,
+  created_at datetime default current_timestamp not null,
+
+  foreign key (batch_id)
+  references batches (id)
+    on update cascade
+    on delete cascade
+);
+
+create table configs (
+  key varchar(255) unique,
+  value text
+);
+
+create table hmpb_templates (
+  id varchar(36) primary key,
+  pdf blob,
+  locales varchar(255),
+  ballot_style_id varchar(255),
+  precinct_id varchar(255),
+  is_test_ballot boolean,
+  layouts_json text,
+  created_at datetime default current_timestamp not null
+);
+
+create unique index hmpb_templates_idx on hmpb_templates (
+  locales,
+  ballot_style_id,
+  precinct_id,
+  is_test_ballot
+);

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -452,6 +452,6 @@ export default class SystemImporter implements Importer {
    */
   public async unconfigure(): Promise<void> {
     await this.doZero()
-    await this.store.init(true) // destroy all data
+    await this.store.reset() // destroy all data
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -320,17 +320,23 @@ export interface StartOptions {
  */
 export async function start({
   port = process.env.PORT || 3002,
-  store = new Store(path.join(__dirname, '..', 'cvrs.db')),
-  scanner = new FujitsuScanner(),
-  importer = new SystemImporter({
-    store,
-    scanner,
-    ...makeTemporaryBallotImportImageDirectories().paths,
-  }),
-  app = buildApp({ importer, store }),
+  store,
+  scanner,
+  importer,
+  app,
   log = console.log,
 }: Partial<StartOptions> = {}): Promise<void> {
-  await store.init()
+  store =
+    store ?? (await Store.fileStore(path.join(__dirname, '..', 'ballots.db')))
+  scanner = scanner ?? new FujitsuScanner()
+  importer =
+    importer ??
+    new SystemImporter({
+      store,
+      scanner,
+      ...makeTemporaryBallotImportImageDirectories().paths,
+    })
+  app = app ?? buildApp({ importer, store })
   await importer.restoreConfig()
 
   app.listen(port, () => {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -102,9 +102,9 @@ test('HMPB template handling', async () => {
 
 test('destroy database', async () => {
   const dbFile = tmp.fileSync()
-  const store = new Store(dbFile.name)
+  const store = await Store.fileStore(dbFile.name)
 
-  await store.init()
+  await store.reset()
   await fs.access(dbFile.name)
 
   await store.dbDestroy()


### PR DESCRIPTION
Changes are detected by creating a digest of the SQL file used to initialize the database. If it matches the `.digest` file associated with a database, it'll open and use the database as normal. If not, either because the digest file does not exist or because the value is different, the existing database will be backed up and a new one created in its place.