### PR TITLE
fix: upgrade election types

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
     '!**/node_modules/**',
     '!src/index.ts',
     '!src/types.ts',
+    '!test/**/*',
   ],
   coverageThreshold: {
     global: {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "dependencies": {
     "@types/sharp": "^0.25.1",
-    "@votingworks/ballot-encoder": "^2.2.0",
-    "@votingworks/hmpb-interpreter": "^4.1.1",
+    "@votingworks/ballot-encoder": "^3.0.0",
+    "@votingworks/hmpb-interpreter": "^4.2.0",
     "@votingworks/qrdetect": "^1.0.1",
     "busboy": "^0.3.1",
     "canvas": "^2.6.1",

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -137,6 +137,8 @@ function ballotToCastVoteRecord(ballot: CompletedBallot): CastVoteRecord {
           candidate.isWriteIn ? '__write-in' : candidate.id
         )
       }
+    } else {
+      throw new Error(`contest type is not yet supported: ${contest.type}`)
     }
 
     cvr[contest.id] = cvrForContest

--- a/src/store.ts
+++ b/src/store.ts
@@ -452,6 +452,12 @@ export default class Store {
                     continue
                   }
 
+                  if (mark.type !== 'candidate' && mark.type !== 'yesno') {
+                    throw new Error(
+                      `contest type is not yet supported: ${mark.type}`
+                    )
+                  }
+
                   if (
                     (mark.type === 'candidate' &&
                       mark.option.id === optionId) ||

--- a/src/util/allContestOptions.ts
+++ b/src/util/allContestOptions.ts
@@ -1,7 +1,5 @@
-import { CandidateContest, YesNoContest } from '@votingworks/ballot-encoder'
+import { AnyContest } from '@votingworks/ballot-encoder'
 import { ContestOption } from '../types'
-
-type AnyContest = CandidateContest | YesNoContest
 
 /**
  * Enumerates all contest options in the order they would appear on a HMPB.
@@ -29,7 +27,7 @@ export default function* allContestOptions(
         }
       }
     }
-  } else {
+  } else if (contest.type === 'yesno') {
     yield {
       type: 'yesno',
       id: 'yes',
@@ -40,5 +38,7 @@ export default function* allContestOptions(
       id: 'no',
       name: 'No',
     }
+  } else {
+    throw new Error(`contest type is not yet supported: ${contest.type}`)
   }
 }

--- a/src/util/ballotAdjudicationReasons.ts
+++ b/src/util/ballotAdjudicationReasons.ts
@@ -75,6 +75,10 @@ export default function* ballotAdjudicationReasons(
     let isBlankBallot = true
 
     for (const contest of contests) {
+      if (contest.type !== 'candidate' && contest.type !== 'yesno') {
+        throw new Error(`contest type is not yet supported: ${contest.type}`)
+      }
+
       const selectedOptionIds: ContestOption['id'][] = []
 
       for (const option of allContestOptions(contest)) {

--- a/src/util/marks.ts
+++ b/src/util/marks.ts
@@ -66,6 +66,10 @@ export function changesFromMarks(
       continue
     }
 
+    if (mark.type !== 'candidate' && mark.type !== 'yesno') {
+      throw new Error(`contest type is not yet supported: ${mark.type}`)
+    }
+
     result[mark.contest.id] = {
       ...result[mark.contest.id],
       [mark.type === 'candidate' ? mark.option.id : mark.option]: getMarkStatus(

--- a/yarn.lock
+++ b/yarn.lock
@@ -959,20 +959,20 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
-"@votingworks/ballot-encoder@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@votingworks/ballot-encoder/-/ballot-encoder-2.2.0.tgz#92400d3165e87538d324c678cd7d63be47a23fc3"
-  integrity sha512-o0nxhQkbNXupGH8Mh3lfyugz33luhKPvmow1gfKcVzoSTJP7fw2/C/gmZnrSkqFiZisEsbW223FyUbgiaR7+UQ==
+"@votingworks/ballot-encoder@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@votingworks/ballot-encoder/-/ballot-encoder-3.0.0.tgz#c82ce28b184ff3828d393b11928517021a6ce855"
+  integrity sha512-IK8wkd0uT6XSjlakvYOthzbEC701ycVU0C050nudNL3+TTCCa6Xtz2x69xOXVedCn0fCo2vrJ5c8OveoFqeFPg==
   dependencies:
     "@antongolub/iso8601" "^1.2.1"
     zod "^1.7.1"
 
-"@votingworks/hmpb-interpreter@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@votingworks/hmpb-interpreter/-/hmpb-interpreter-4.1.1.tgz#39eed65d6db9cc02c1b9d36b6505043a54fa923f"
-  integrity sha512-XRp5v/kI8pCgRP+BcM0kn3aTcGxIbL/V6DLd8qc7E3ftVNSpeqUTBjOnmgZkGVCGBw02wb1c6MAm/Wboh+MVYQ==
+"@votingworks/hmpb-interpreter@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@votingworks/hmpb-interpreter/-/hmpb-interpreter-4.2.0.tgz#1b7f02fe442e027828bc960760bb407da614e04f"
+  integrity sha512-opkUJ/fw1wCqsDELVoDfAMhMcLZY91QSOpilZFLMouCAH2dRRBpN+RAzIwWVhCn92COIGBPVeTRl0l5nOZ0x1Q==
   dependencies:
-    "@votingworks/ballot-encoder" "^2.2.0"
+    "@votingworks/ballot-encoder" "^3.0.0"
     canvas "^2.6.1"
     chalk "^4.0.0"
     debug "^4.1.1"


### PR DESCRIPTION
This mostly incorporates the new contest type `ms-either-neither` while also being more explicit about what contest types we handle. For now, just fail on anything not `candidate` or `yesno`.