### PR TITLE
refactor: remove manual ballots

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      statements: 92,
+      statements: 91,
       branches: 80,
       functions: 92,
       lines: 91,

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -51,17 +51,11 @@ export type InterpretedBallot =
   | InterpretedBmdBallot
   | InterpretedHmpbBallot
   | UninterpretedHmpbBallot
-  | ManualBallot
   | InvalidTestModeBallot
 
 export interface UninterpretedHmpbBallot {
   type: 'UninterpretedHmpbBallot'
   metadata: BallotPageMetadata
-}
-
-export interface ManualBallot {
-  type: 'ManualBallot'
-  cvr: CastVoteRecord
 }
 
 export interface InterpretedBmdBallot {

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -168,18 +168,6 @@ test('POST /scan/scanFiles', async () => {
     .expect(200, { status: 'ok' })
 })
 
-test('POST /scan/addManualBallot', async () => {
-  importerMock.addManualBallot.mockResolvedValue(undefined)
-  await request(app)
-    .post('/scan/addManualBallot')
-    .send({
-      ballotString: '12.23.1|0|0|0||||||||||||||||.r6UYR4t7hEFMz8ZlMWf1Sw',
-    })
-    .set('Accept', 'application/json')
-    .expect(200, { status: 'ok' })
-  expect(importer.addManualBallot).toBeCalled()
-})
-
 test('POST /scan/invalidateBatch', async () => {
   await request(app)
     .post('/scan/invalidateBatch')

--- a/src/server.ts
+++ b/src/server.ts
@@ -145,12 +145,6 @@ export function buildApp({ store, importer }: AppOptions): Application {
     response.json({ status: 'ok' })
   })
 
-  app.post('/scan/addManualBallot', async (request, response) => {
-    const { ballotString } = request.body
-    await importer.addManualBallot(new TextEncoder().encode(ballotString))
-    response.json({ status: 'ok' })
-  })
-
   app.post(
     '/scan/hmpb/addTemplates',
     upload.fields([

--- a/test/util/mocks.ts
+++ b/test/util/mocks.ts
@@ -16,7 +16,6 @@ export function makeMockInterpreter(): jest.Mocked<Interpreter> {
 export function makeMockImporter(): jest.Mocked<Importer> {
   return {
     addHmpbTemplates: jest.fn(),
-    addManualBallot: jest.fn(),
     configure: jest.fn(),
     doExport: jest.fn(),
     doImport: jest.fn(),


### PR DESCRIPTION
We no longer need this, and it's going to be annoying to preserve it in a world where we interpret one sheet at a time.