### PR TITLE
refactor: use the file system for all imports

### DIFF
--- a/src/importer.test.ts
+++ b/src/importer.test.ts
@@ -1,7 +1,9 @@
 import { electionSample as election } from '@votingworks/ballot-encoder'
 import { createImageData } from 'canvas'
 import * as fs from 'fs-extra'
+import { join } from 'path'
 import sharp from 'sharp'
+import { fileSync } from 'tmp'
 import { makeMockInterpreter } from '../test/util/mocks'
 import SystemImporter from './importer'
 import { Scanner, Sheet } from './scanner'
@@ -10,7 +12,6 @@ import makeTemporaryBallotImportImageDirectories, {
   TemporaryBallotImportImageDirectories,
 } from './util/makeTemporaryBallotImportImageDirectories'
 import pdfToImages from './util/pdfToImages'
-import { join } from 'path'
 
 const sampleBallotImagesPath = join(__dirname, '..', 'sample-ballot-images/')
 
@@ -229,14 +230,15 @@ test('manually importing a buffer as a file', async () => {
       pageCount: 2,
     },
   })
+  const imageFile = fileSync()
+  await sharp({
+    create: { width: 1, height: 1, channels: 3, background: '#000' },
+  })
+    .png()
+    .toFile(imageFile.name)
   const ballotId = (await importer.importFile(
     await store.addBatch(),
-    '/tmp/fake-path.png',
-    await sharp({
-      create: { width: 1, height: 1, channels: 3, background: '#000' },
-    })
-      .png()
-      .toBuffer()
+    imageFile.name
   ))!
 
   const filenames = (await store.getBallotFilenames(ballotId))!

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -40,8 +40,7 @@ export interface Importer {
   doZero(): Promise<void>
   importFile(
     batchId: string,
-    ballotImagePath: string,
-    ballotImageFile?: Buffer
+    ballotImagePath: string
   ): Promise<string | undefined>
   getStatus(): Promise<ScanStatus>
   restoreConfig(): Promise<void>
@@ -247,7 +246,7 @@ export default class SystemImporter implements Importer {
     const start = Date.now()
     try {
       debug('fileAdded %s batchId=%d STARTING', ballotImagePath, batchId)
-      await this.importFile(batchId, ballotImagePath, undefined)
+      await this.importFile(batchId, ballotImagePath)
     } finally {
       const end = Date.now()
       debug(
@@ -261,8 +260,7 @@ export default class SystemImporter implements Importer {
 
   public async importFile(
     batchId: string,
-    ballotImagePath: string,
-    ballotImageFile?: Buffer
+    ballotImagePath: string
   ): Promise<string | undefined> {
     const election = await this.store.getElection()
 
@@ -270,10 +268,7 @@ export default class SystemImporter implements Importer {
       return
     }
 
-    if (!ballotImageFile) {
-      ballotImageFile = await fsExtra.readFile(ballotImagePath)
-    }
-
+    const ballotImageFile = await fsExtra.readFile(ballotImagePath)
     const ballotImageHash = createHash('sha256')
       .update(ballotImageFile)
       .digest('hex')

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,16 +3,17 @@
 // All actual implementations are in importer.ts and scanner.ts
 //
 
+import { parseElection } from '@votingworks/ballot-encoder'
 import express, { Application, RequestHandler } from 'express'
+import { readFile } from 'fs-extra'
 import multer from 'multer'
 import * as path from 'path'
+import { inspect } from 'util'
 import SystemImporter, { Importer } from './importer'
 import { FujitsuScanner, Scanner } from './scanner'
 import Store, { ALLOWED_CONFIG_KEYS, ConfigKey } from './store'
 import { BallotConfig } from './types'
 import makeTemporaryBallotImportImageDirectories from './util/makeTemporaryBallotImportImageDirectories'
-import { parseElection } from '@votingworks/ballot-encoder'
-import { inspect } from 'util'
 
 export interface AppOptions {
   store: Store
@@ -25,7 +26,7 @@ export interface AppOptions {
  */
 export function buildApp({ store, importer }: AppOptions): Application {
   const app: Application = express()
-  const upload = multer({ storage: multer.memoryStorage() })
+  const upload = multer({ storage: multer.diskStorage({}) })
 
   app.use(express.json())
 
@@ -121,11 +122,7 @@ export function buildApp({ store, importer }: AppOptions): Application {
 
           for (const file of files) {
             try {
-              await importer.importFile(
-                batchId,
-                `batch-${batchId}-manual-upload-${file.originalname}`,
-                file.buffer
-              )
+              await importer.importFile(batchId, file.path)
             } catch (error) {
               console.error(
                 `failed to import file ${file.originalname}: ${error.message}`
@@ -203,10 +200,10 @@ export function buildApp({ store, importer }: AppOptions): Application {
           }
 
           const metadata: BallotConfig = JSON.parse(
-            new TextDecoder().decode(metadataFile.buffer)
+            new TextDecoder().decode(await readFile(metadataFile.path))
           )
 
-          await importer.addHmpbTemplates(ballotFile.buffer, {
+          await importer.addHmpbTemplates(await readFile(ballotFile.path), {
             ballotStyleId: metadata.ballotStyleId,
             precinctId: metadata.precinctId,
             isTestBallot: !metadata.isLiveMode,


### PR DESCRIPTION
This simplifies the importer API.