### PR TITLE
feat: record an interpretation for every page

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -12,6 +12,7 @@ create table ballots (
   batch_id varchar(36),
   original_filename text unique,
   normalized_filename text unique,
+  interpretation_json text not null,
   marks_json text,
   cvr_json text,
   metadata_json text,

--- a/src/endToEnd.test.ts
+++ b/src/endToEnd.test.ts
@@ -84,7 +84,7 @@ test('going through the whole process works', async () => {
       .set('Accept', 'application/json')
       .expect(200)
 
-    expect(JSON.parse(status.text).batches[0].count).toBe(3)
+    expect(JSON.parse(status.text).batches[0].count).toBe(6)
   }
 
   {

--- a/src/importer.test.ts
+++ b/src/importer.test.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs-extra'
 import { join } from 'path'
 import sharp from 'sharp'
 import { fileSync } from 'tmp'
+import { v4 as uuid } from 'uuid'
 import { makeMockInterpreter } from '../test/util/mocks'
 import SystemImporter from './importer'
 import { Scanner, Sheet } from './scanner'
@@ -94,16 +95,22 @@ test('setTestMode zeroes and sets test mode on the interpreter', async () => {
 
   await importer.configure(election)
   const batchId = await store.addBatch()
-  await store.addBallot(batchId, '/tmp/page.png', '/tmp/normalized-page.png', {
-    type: 'UninterpretedHmpbBallot',
-    metadata: {
-      ballotStyleId: '12',
-      precinctId: '23',
-      isTestBallot: false,
-      pageNumber: 1,
-      pageCount: 2,
-    },
-  })
+  await store.addBallot(
+    uuid(),
+    batchId,
+    '/tmp/page.png',
+    '/tmp/normalized-page.png',
+    {
+      type: 'UninterpretedHmpbBallot',
+      metadata: {
+        ballotStyleId: '12',
+        precinctId: '23',
+        isTestBallot: false,
+        pageNumber: 1,
+        pageCount: 2,
+      },
+    }
+  )
   expect((await importer.getStatus()).batches).toHaveLength(1)
 
   await importer.setTestMode(true)

--- a/src/importer.test.ts
+++ b/src/importer.test.ts
@@ -219,13 +219,15 @@ test('manually importing a buffer as a file', async () => {
 
   await store.setElection(election)
   interpreter.interpretFile.mockResolvedValueOnce({
-    type: 'UninterpretedHmpbPage',
-    metadata: {
-      ballotStyleId: '77',
-      precinctId: '42',
-      isTestBallot: false,
-      pageNumber: 1,
-      pageCount: 2,
+    interpretation: {
+      type: 'UninterpretedHmpbPage',
+      metadata: {
+        ballotStyleId: '77',
+        precinctId: '42',
+        isTestBallot: false,
+        pageNumber: 1,
+        pageCount: 2,
+      },
     },
   })
   const imageFile = fileSync()

--- a/src/importer.test.ts
+++ b/src/importer.test.ts
@@ -101,7 +101,7 @@ test('setTestMode zeroes and sets test mode on the interpreter', async () => {
     '/tmp/page.png',
     '/tmp/normalized-page.png',
     {
-      type: 'UninterpretedHmpbBallot',
+      type: 'UninterpretedHmpbPage',
       metadata: {
         ballotStyleId: '12',
         precinctId: '23',
@@ -219,7 +219,7 @@ test('manually importing a buffer as a file', async () => {
 
   await store.setElection(election)
   interpreter.interpretFile.mockResolvedValueOnce({
-    type: 'UninterpretedHmpbBallot',
+    type: 'UninterpretedHmpbPage',
     metadata: {
       ballotStyleId: '77',
       precinctId: '42',

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -184,13 +184,13 @@ export default class SystemImporter implements Importer {
   private async cardAdded(card: Sheet, batchId: string): Promise<void> {
     const start = Date.now()
     try {
-      debug('cardAdded %o batchId=%d STARTING', card, batchId)
+      debug('cardAdded %o batchId=%s STARTING', card, batchId)
       await this.fileAdded(card[0], batchId)
       await this.fileAdded(card[1], batchId)
     } finally {
       const end = Date.now()
       debug(
-        'cardAdded %o batchId=%d FINISHED in %dms',
+        'cardAdded %o batchId=%s FINISHED in %dms',
         card,
         batchId,
         Math.round(end - start)
@@ -207,12 +207,12 @@ export default class SystemImporter implements Importer {
   ): Promise<void> {
     const start = Date.now()
     try {
-      debug('fileAdded %s batchId=%d STARTING', ballotImagePath, batchId)
+      debug('fileAdded %s batchId=%s STARTING', ballotImagePath, batchId)
       await this.importFile(batchId, ballotImagePath)
     } finally {
       const end = Date.now()
       debug(
-        'fileAdded %s batchId=%d FINISHED in %dms',
+        'fileAdded %s batchId=%s FINISHED in %dms',
         ballotImagePath,
         batchId,
         Math.round(end - start)
@@ -349,7 +349,7 @@ export default class SystemImporter implements Importer {
 
     try {
       // trigger a scan
-      debug('scanning starting for batch: %d', batchId)
+      debug('scanning starting for batch: %s', batchId)
       for await (const sheet of this.scanner.scanSheets(
         this.ballotImagesPath
       )) {
@@ -361,7 +361,7 @@ export default class SystemImporter implements Importer {
       // node couldn't execute the command
       throw new Error(`problem scanning: ${err.stack}`)
     } finally {
-      debug('closing batch %d', batchId)
+      debug('closing batch %s', batchId)
       await this.store.finishBatch(batchId)
     }
   }

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'crypto'
 import makeDebug from 'debug'
 import sharp, { Raw } from 'sharp'
 import * as path from 'path'
@@ -232,9 +231,7 @@ export default class SystemImporter implements Importer {
     }
 
     const ballotImageFile = await fsExtra.readFile(ballotImagePath)
-    const ballotImageHash = createHash('sha256')
-      .update(ballotImageFile)
-      .digest('hex')
+    let ballotId = uuid()
 
     const interpreted = await this.interpreter.interpretFile({
       election,
@@ -269,17 +266,17 @@ export default class SystemImporter implements Importer {
       `${path.basename(
         ballotImagePath,
         ballotImagePathExt
-      )}-${ballotImageHash}-original${ballotImagePathExt}`
+      )}-${ballotId}-original${ballotImagePathExt}`
     )
     const normalizedBallotImagePath = path.join(
       this.importedBallotImagesPath,
       `${path.basename(
         ballotImagePath,
         ballotImagePathExt
-      )}-${ballotImageHash}-normalized${ballotImagePathExt}`
+      )}-${ballotId}-normalized${ballotImagePathExt}`
     )
 
-    const ballotId = await this.addBallot(
+    ballotId = await this.addBallot(
       batchId,
       originalBallotImagePath,
       normalizedBallotImagePath,

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -233,25 +233,16 @@ export default class SystemImporter implements Importer {
     const ballotImageFile = await fsExtra.readFile(ballotImagePath)
     let ballotId = uuid()
 
-    const interpretation = await this.interpreter.interpretFile({
+    const {
+      interpretation,
+      normalizedImage,
+    } = await this.interpreter.interpretFile({
       election,
       ballotImagePath,
       ballotImageFile,
     })
 
-    // TODO: Handle invalid test mode ballots more explicitly.
-    // At some point we want to present information to the user that tells them
-    // there was a ballot that was did not match the test/live mode of the
-    // scanner. For now we just ignore such ballots completely.
-    if (!interpretation || interpretation.type === 'InvalidTestModePage') {
-      return
-    }
-
     const cvr = 'cvr' in interpretation ? interpretation.cvr : undefined
-    const normalizedImage =
-      'normalizedImage' in interpretation
-        ? interpretation.normalizedImage
-        : undefined
 
     debug(
       'interpreted %s (%s): cvr=%O marks=%O metadata=%O',

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -5,6 +5,7 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as streams from 'memory-streams'
 import * as fsExtra from 'fs-extra'
+import { v4 as uuid } from 'uuid'
 import { Election } from '@votingworks/ballot-encoder'
 import { BallotPageLayout } from '@votingworks/hmpb-interpreter'
 
@@ -326,6 +327,7 @@ export default class SystemImporter implements Importer {
     interpreted: InterpretedBallot
   ): Promise<string> {
     const ballotId = await this.store.addBallot(
+      uuid(),
       batchId,
       originalBallotImagePath,
       normalizedBallotImagePath,

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -22,8 +22,8 @@ const debug = makeDebug('module-scan:importer')
 export interface Options {
   store: Store
   scanner: Scanner
-  ballotImagesPath: string
-  importedBallotImagesPath: string
+  scannedImagesPath: string
+  importedImagesPath: string
   interpreter?: Interpreter
 }
 
@@ -56,31 +56,31 @@ export default class SystemImporter implements Importer {
   private scanner: Scanner
   private interpreter: Interpreter
 
-  public readonly ballotImagesPath: string
-  public readonly importedBallotImagesPath: string
+  public readonly scannedImagesPath: string
+  public readonly importedImagesPath: string
 
   /**
    * @param param0 options for this importer
    * @param param0.store a data store to track scanned ballot images
    * @param param0.scanner a source of ballot images
-   * @param param0.ballotImagesPath a directory to scan ballot images into
-   * @param param0.scannedBallotImagesPath a directory to keep imported ballot images
+   * @param param0.scannedImagesPath a directory to scan ballot images into
+   * @param param0.importedImagesPath a directory to keep imported ballot images
    */
   public constructor({
     store,
     scanner,
-    ballotImagesPath,
-    importedBallotImagesPath,
+    scannedImagesPath,
+    importedImagesPath,
     interpreter = new DefaultInterpreter(),
   }: Options) {
     this.store = store
     this.scanner = scanner
     this.interpreter = interpreter
-    this.ballotImagesPath = ballotImagesPath
-    this.importedBallotImagesPath = importedBallotImagesPath
+    this.scannedImagesPath = scannedImagesPath
+    this.importedImagesPath = importedImagesPath
 
     // make sure those directories exist
-    for (const imagesPath of [ballotImagesPath, importedBallotImagesPath]) {
+    for (const imagesPath of [scannedImagesPath, importedImagesPath]) {
       if (!fs.existsSync(imagesPath)) {
         fs.mkdirSync(imagesPath)
       }
@@ -262,14 +262,14 @@ export default class SystemImporter implements Importer {
 
     const ballotImagePathExt = path.extname(ballotImagePath)
     const originalBallotImagePath = path.join(
-      this.importedBallotImagesPath,
+      this.importedImagesPath,
       `${path.basename(
         ballotImagePath,
         ballotImagePathExt
       )}-${ballotId}-original${ballotImagePathExt}`
     )
     const normalizedBallotImagePath = path.join(
-      this.importedBallotImagesPath,
+      this.importedImagesPath,
       `${path.basename(
         ballotImagePath,
         ballotImagePathExt
@@ -350,7 +350,7 @@ export default class SystemImporter implements Importer {
       // trigger a scan
       debug('scanning starting for batch: %s', batchId)
       for await (const sheet of this.scanner.scanSheets(
-        this.ballotImagesPath
+        this.scannedImagesPath
       )) {
         debug('got a ballot card: %o', sheet)
         await this.cardAdded(sheet, batchId)
@@ -385,8 +385,8 @@ export default class SystemImporter implements Importer {
    */
   public async doZero(): Promise<void> {
     await this.store.zero()
-    fsExtra.emptyDirSync(this.ballotImagesPath)
-    fsExtra.emptyDirSync(this.importedBallotImagesPath)
+    fsExtra.emptyDirSync(this.scannedImagesPath)
+    fsExtra.emptyDirSync(this.importedImagesPath)
   }
 
   /**

--- a/src/interpreter.test.ts
+++ b/src/interpreter.test.ts
@@ -1,12 +1,12 @@
 import { electionSample } from '@votingworks/ballot-encoder'
 import { readFile } from 'fs-extra'
 import { join } from 'path'
-import stateOfHamiltonElection from '../test/fixtures/state-of-hamilton/election'
 import choctaw2020Election from '../test/fixtures/2020-choctaw/election'
+import stateOfHamiltonElection from '../test/fixtures/state-of-hamilton/election'
 import SummaryBallotInterpreter, {
   getBallotImageData,
-  InterpretedHmpbBallot,
-  UninterpretedHmpbBallot,
+  InterpretedHmpbPage,
+  UninterpretedHmpbPage,
 } from './interpreter'
 import pdfToImages from './util/pdfToImages'
 
@@ -65,7 +65,7 @@ test('extracts a CVR from votes encoded in a QR code', async () => {
       election: electionSample,
       ballotImagePath,
       ballotImageFile: await readFile(ballotImagePath),
-    })) as InterpretedHmpbBallot).cvr
+    })) as InterpretedHmpbPage).cvr
   ).toEqual(
     expect.objectContaining({
       _ballotId: 'r6UYR4t7hEFMz8QlMWf1Sw',
@@ -100,7 +100,7 @@ test('interprets marks on a HMPB', async () => {
     election: stateOfHamiltonElection,
     ballotImagePath,
     ballotImageFile: await readFile(ballotImagePath),
-  })) as InterpretedHmpbBallot).cvr
+  })) as InterpretedHmpbPage).cvr
 
   delete cvr?._ballotId
 
@@ -152,7 +152,7 @@ test('interprets marks on an upside-down HMPB', async () => {
     election: stateOfHamiltonElection,
     ballotImagePath,
     ballotImageFile: await readFile(ballotImagePath),
-  })) as InterpretedHmpbBallot).cvr
+  })) as InterpretedHmpbPage).cvr
 
   delete cvr?._ballotId
 
@@ -200,7 +200,7 @@ test('interprets marks in PNG ballots', async () => {
       election: choctaw2020Election,
       ballotImagePath,
       ballotImageFile: await readFile(ballotImagePath),
-    })) as InterpretedHmpbBallot).cvr
+    })) as InterpretedHmpbPage).cvr
 
     delete cvr?._ballotId
 
@@ -243,7 +243,7 @@ test('interprets marks in PNG ballots', async () => {
       election: choctaw2020Election,
       ballotImagePath,
       ballotImageFile: await readFile(ballotImagePath),
-    })) as InterpretedHmpbBallot).cvr
+    })) as InterpretedHmpbPage).cvr
 
     delete cvr?._ballotId
 
@@ -293,7 +293,7 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
       election: stateOfHamiltonElection,
       ballotImagePath,
       ballotImageFile: await readFile(ballotImagePath),
-    })) as UninterpretedHmpbBallot
+    })) as UninterpretedHmpbPage
   ).toMatchInlineSnapshot(`
     Object {
       "metadata": Object {
@@ -307,7 +307,7 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
         "pageNumber": 3,
         "precinctId": "23",
       },
-      "type": "UninterpretedHmpbBallot",
+      "type": "UninterpretedHmpbPage",
     }
   `)
 })

--- a/src/interpreter.test.ts
+++ b/src/interpreter.test.ts
@@ -8,6 +8,7 @@ import SummaryBallotInterpreter, {
   InterpretedHmpbPage,
   UninterpretedHmpbPage,
 } from './interpreter'
+import { resultValue, resultError } from './types'
 import pdfToImages from './util/pdfToImages'
 
 const sampleBallotImagesPath = join(__dirname, '..', 'sample-ballot-images/')
@@ -24,9 +25,8 @@ const choctaw2020FixturesRoot = join(
 
 test('reads QR codes from ballot images #1', async () => {
   const filepath = join(sampleBallotImagesPath, 'sample-batch-1-ballot-1.jpg')
-  const { qrcode } = await getBallotImageData(
-    await readFile(filepath),
-    filepath
+  const { qrcode } = resultValue(
+    await getBallotImageData(await readFile(filepath), filepath)
   )
 
   expect(qrcode).toEqual(
@@ -36,9 +36,8 @@ test('reads QR codes from ballot images #1', async () => {
 
 test('reads QR codes from ballot images #2', async () => {
   const filepath = join(sampleBallotImagesPath, 'sample-batch-1-ballot-2.jpg')
-  const { qrcode } = await getBallotImageData(
-    await readFile(filepath),
-    filepath
+  const { qrcode } = resultValue(
+    await getBallotImageData(await readFile(filepath), filepath)
   )
 
   expect(qrcode).toEqual(
@@ -50,9 +49,9 @@ test('reads QR codes from ballot images #2', async () => {
 
 test('does not find QR codes when there are none to find', async () => {
   const filepath = join(sampleBallotImagesPath, 'not-a-ballot.jpg')
-  await expect(
-    getBallotImageData(await readFile(filepath), filepath)
-  ).rejects.toThrowError('no QR code found')
+  expect(
+    resultError(await getBallotImageData(await readFile(filepath), filepath))
+  ).toEqual({ type: 'UnreadablePage', reason: 'No QR code found' })
 })
 
 test('extracts a CVR from votes encoded in a QR code', async () => {
@@ -61,11 +60,13 @@ test('extracts a CVR from votes encoded in a QR code', async () => {
     'sample-batch-1-ballot-1.jpg'
   )
   expect(
-    ((await new SummaryBallotInterpreter().interpretFile({
-      election: electionSample,
-      ballotImagePath,
-      ballotImageFile: await readFile(ballotImagePath),
-    })) as InterpretedHmpbPage).cvr
+    ((
+      await new SummaryBallotInterpreter().interpretFile({
+        election: electionSample,
+        ballotImagePath,
+        ballotImageFile: await readFile(ballotImagePath),
+      })
+    ).interpretation as InterpretedHmpbPage).cvr
   ).toEqual(
     expect.objectContaining({
       _ballotId: 'r6UYR4t7hEFMz8QlMWf1Sw',
@@ -96,11 +97,13 @@ test('interprets marks on a HMPB', async () => {
     stateOfHamiltonFixturesRoot,
     'filled-in-dual-language-p1.jpg'
   )
-  const cvr = ((await interpreter.interpretFile({
-    election: stateOfHamiltonElection,
-    ballotImagePath,
-    ballotImageFile: await readFile(ballotImagePath),
-  })) as InterpretedHmpbPage).cvr
+  const cvr = ((
+    await interpreter.interpretFile({
+      election: stateOfHamiltonElection,
+      ballotImagePath,
+      ballotImageFile: await readFile(ballotImagePath),
+    })
+  ).interpretation as InterpretedHmpbPage).cvr
 
   delete cvr?._ballotId
 
@@ -148,11 +151,13 @@ test('interprets marks on an upside-down HMPB', async () => {
     stateOfHamiltonFixturesRoot,
     'filled-in-dual-language-p1-flipped.jpg'
   )
-  const cvr = ((await interpreter.interpretFile({
-    election: stateOfHamiltonElection,
-    ballotImagePath,
-    ballotImageFile: await readFile(ballotImagePath),
-  })) as InterpretedHmpbPage).cvr
+  const cvr = ((
+    await interpreter.interpretFile({
+      election: stateOfHamiltonElection,
+      ballotImagePath,
+      ballotImageFile: await readFile(ballotImagePath),
+    })
+  ).interpretation as InterpretedHmpbPage).cvr
 
   delete cvr?._ballotId
 
@@ -196,11 +201,13 @@ test('interprets marks in PNG ballots', async () => {
 
   {
     const ballotImagePath = join(choctaw2020FixturesRoot, 'filled-in-p1.png')
-    const cvr = ((await interpreter.interpretFile({
-      election: choctaw2020Election,
-      ballotImagePath,
-      ballotImageFile: await readFile(ballotImagePath),
-    })) as InterpretedHmpbPage).cvr
+    const cvr = ((
+      await interpreter.interpretFile({
+        election: choctaw2020Election,
+        ballotImagePath,
+        ballotImageFile: await readFile(ballotImagePath),
+      })
+    ).interpretation as InterpretedHmpbPage).cvr
 
     delete cvr?._ballotId
 
@@ -239,11 +246,13 @@ test('interprets marks in PNG ballots', async () => {
 
   {
     const ballotImagePath = join(choctaw2020FixturesRoot, 'filled-in-p2.png')
-    const cvr = ((await interpreter.interpretFile({
-      election: choctaw2020Election,
-      ballotImagePath,
-      ballotImageFile: await readFile(ballotImagePath),
-    })) as InterpretedHmpbPage).cvr
+    const cvr = ((
+      await interpreter.interpretFile({
+        election: choctaw2020Election,
+        ballotImagePath,
+        ballotImageFile: await readFile(ballotImagePath),
+      })
+    ).interpretation as InterpretedHmpbPage).cvr
 
     delete cvr?._ballotId
 
@@ -289,11 +298,13 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
     'filled-in-dual-language-p3.jpg'
   )
   expect(
-    (await interpreter.interpretFile({
-      election: stateOfHamiltonElection,
-      ballotImagePath,
-      ballotImageFile: await readFile(ballotImagePath),
-    })) as UninterpretedHmpbPage
+    (
+      await interpreter.interpretFile({
+        election: stateOfHamiltonElection,
+        ballotImagePath,
+        ballotImageFile: await readFile(ballotImagePath),
+      })
+    ).interpretation as UninterpretedHmpbPage
   ).toMatchInlineSnapshot(`
     Object {
       "metadata": Object {

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -159,7 +159,7 @@ test('POST /scan/scanBatch errors', async () => {
 })
 
 test('POST /scan/scanFiles', async () => {
-  importerMock.importFile.mockResolvedValueOnce(undefined)
+  importerMock.importFile.mockResolvedValueOnce(uuid())
   await request(app)
     .post('/scan/scanFiles')
     .attach('files', Buffer.of(), {
@@ -208,7 +208,7 @@ test('GET /scan/hmpb/ballot/:ballotId', async () => {
     '/tmp/image.jpg',
     '/tmp/image-normalized.jpg',
     {
-      type: 'InterpretedHmpbBallot',
+      type: 'InterpretedHmpbPage',
       normalizedImage: EMPTY_IMAGE,
       cvr: {
         _ballotId: 'abc',
@@ -293,7 +293,7 @@ test('PATCH /scan/hmpb/ballot/:ballotId', async () => {
     '/tmp/image.jpg',
     '/tmp/image-normalized.jpg',
     {
-      type: 'InterpretedHmpbBallot',
+      type: 'InterpretedHmpbPage',
       normalizedImage: EMPTY_IMAGE,
       cvr: {
         _ballotId: 'abc',
@@ -436,7 +436,7 @@ test('GET /scan/hmpb/ballot/:ballotId/image', async () => {
     original,
     normalized,
     {
-      type: 'InterpretedHmpbBallot',
+      type: 'InterpretedHmpbPage',
       normalizedImage: EMPTY_IMAGE,
       metadata: {
         ballotStyleId: '12',

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -12,7 +12,6 @@ import { Server } from 'http'
 import { join } from 'path'
 import request from 'supertest'
 import { v4 as uuid } from 'uuid'
-import EMPTY_IMAGE from '../test/fixtures/emptyImage'
 import election from '../test/fixtures/state-of-hamilton/election'
 import zeroRect from '../test/fixtures/zeroRect'
 import { makeMockImporter } from '../test/util/mocks'
@@ -209,7 +208,6 @@ test('GET /scan/hmpb/ballot/:ballotId', async () => {
     '/tmp/image-normalized.jpg',
     {
       type: 'InterpretedHmpbPage',
-      normalizedImage: EMPTY_IMAGE,
       cvr: {
         _ballotId: 'abc',
         _ballotStyleId: '12',
@@ -294,7 +292,6 @@ test('PATCH /scan/hmpb/ballot/:ballotId', async () => {
     '/tmp/image-normalized.jpg',
     {
       type: 'InterpretedHmpbPage',
-      normalizedImage: EMPTY_IMAGE,
       cvr: {
         _ballotId: 'abc',
         _ballotStyleId: '12',
@@ -437,7 +434,6 @@ test('GET /scan/hmpb/ballot/:ballotId/image', async () => {
     normalized,
     {
       type: 'InterpretedHmpbPage',
-      normalizedImage: EMPTY_IMAGE,
       metadata: {
         ballotStyleId: '12',
         precinctId: '23',

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -11,6 +11,7 @@ import { promises as fs } from 'fs'
 import { Server } from 'http'
 import { join } from 'path'
 import request from 'supertest'
+import { v4 as uuid } from 'uuid'
 import EMPTY_IMAGE from '../test/fixtures/emptyImage'
 import election from '../test/fixtures/state-of-hamilton/election'
 import zeroRect from '../test/fixtures/zeroRect'
@@ -202,6 +203,7 @@ test('GET /scan/hmpb/ballot/:ballotId', async () => {
   const option = contest.candidates[0]
   const batchId = await store.addBatch()
   const ballotId = await store.addBallot(
+    uuid(),
     batchId,
     '/tmp/image.jpg',
     '/tmp/image-normalized.jpg',
@@ -286,6 +288,7 @@ test('PATCH /scan/hmpb/ballot/:ballotId', async () => {
   const yesnoOption = 'no'
   const batchId = await store.addBatch()
   const ballotId = await store.addBallot(
+    uuid(),
     batchId,
     '/tmp/image.jpg',
     '/tmp/image-normalized.jpg',
@@ -427,28 +430,34 @@ test('GET /scan/hmpb/ballot/:ballotId/image', async () => {
     '../test/fixtures/state-of-hamilton/filled-in-dual-language-p1.jpg'
   )
   const batchId = await store.addBatch()
-  const ballotId = await store.addBallot(batchId, original, normalized, {
-    type: 'InterpretedHmpbBallot',
-    normalizedImage: EMPTY_IMAGE,
-    metadata: {
-      ballotStyleId: '12',
-      precinctId: '23',
-      isTestBallot: false,
-      pageNumber: 1,
-      pageCount: 5,
-    },
-    cvr: {
-      _ballotId: 'abc',
-      _ballotStyleId: '12',
-      _precinctId: '23',
-      _scannerId: 'def',
-      _testBallot: false,
-    },
-    markInfo: {
-      ballotSize: { width: 0, height: 0 },
-      marks: [],
-    },
-  })
+  const ballotId = await store.addBallot(
+    uuid(),
+    batchId,
+    original,
+    normalized,
+    {
+      type: 'InterpretedHmpbBallot',
+      normalizedImage: EMPTY_IMAGE,
+      metadata: {
+        ballotStyleId: '12',
+        precinctId: '23',
+        isTestBallot: false,
+        pageNumber: 1,
+        pageCount: 5,
+      },
+      cvr: {
+        _ballotId: 'abc',
+        _ballotStyleId: '12',
+        _precinctId: '23',
+        _scannerId: 'def',
+        _testBallot: false,
+      },
+      markInfo: {
+        ballotSize: { width: 0, height: 0 },
+        marks: [],
+      },
+    }
+  )
   await store.finishBatch(batchId)
 
   await request(app)

--- a/src/server.ts
+++ b/src/server.ts
@@ -334,7 +334,7 @@ export async function start({
     log(`Listening at http://localhost:${port}/`)
 
     if (importer instanceof SystemImporter) {
-      log(`Scanning ballots into ${importer.ballotImagesPath}`)
+      log(`Scanning ballots into ${importer.scannedImagesPath}`)
     }
   })
 }

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -183,7 +183,7 @@ test('adjudication', async () => {
     '/a/ballot-original.jpg',
     '/a/ballot-normalized.jpg',
     {
-      type: 'InterpretedHmpbBallot',
+      type: 'InterpretedHmpbPage',
       normalizedImage: EMPTY_IMAGE,
       cvr: {
         _ballotId: 'abcde',

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,7 +1,7 @@
 import {
+  AdjudicationReason,
   CandidateContest,
   YesNoContest,
-  AdjudicationReason,
 } from '@votingworks/ballot-encoder'
 import { promises as fs } from 'fs'
 import * as tmp from 'tmp'
@@ -10,7 +10,6 @@ import election from '../test/fixtures/state-of-hamilton/election'
 import zeroRect from '../test/fixtures/zeroRect'
 import Store from './store'
 import { MarkStatus } from './types/ballot-review'
-import EMPTY_IMAGE from '../test/fixtures/emptyImage'
 
 test('get/set election', async () => {
   const store = await Store.memoryStore()
@@ -184,7 +183,6 @@ test('adjudication', async () => {
     '/a/ballot-normalized.jpg',
     {
       type: 'InterpretedHmpbPage',
-      normalizedImage: EMPTY_IMAGE,
       cvr: {
         _ballotId: 'abcde',
         _ballotStyleId: '12',

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -5,6 +5,7 @@ import {
 } from '@votingworks/ballot-encoder'
 import { promises as fs } from 'fs'
 import * as tmp from 'tmp'
+import { v4 as uuid } from 'uuid'
 import election from '../test/fixtures/state-of-hamilton/election'
 import zeroRect from '../test/fixtures/zeroRect'
 import Store from './store'
@@ -177,6 +178,7 @@ test('adjudication', async () => {
   ])
   const batchId = await store.addBatch()
   const ballotId = await store.addBallot(
+    uuid(),
     batchId,
     '/a/ballot-original.jpg',
     '/a/ballot-normalized.jpg',

--- a/src/store.ts
+++ b/src/store.ts
@@ -494,12 +494,13 @@ export default class Store {
     try {
       await this.dbRunAsync(
         `insert into ballots
-          (id, batch_id, original_filename, normalized_filename, cvr_json, marks_json, metadata_json, requires_adjudication, adjudication_info_json)
-          values (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          (id, batch_id, original_filename, normalized_filename, interpretation_json, cvr_json, marks_json, metadata_json, requires_adjudication, adjudication_info_json)
+          values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         ballotId,
         batchId,
         originalFilename,
         normalizedFilename,
+        JSON.stringify(interpretation),
         JSON.stringify(cvr),
         markInfo ? JSON.stringify(markInfo, undefined, 2) : null,
         metadata ? JSON.stringify(metadata, undefined, 2) : null,

--- a/src/store.ts
+++ b/src/store.ts
@@ -23,7 +23,7 @@ import sharp from 'sharp'
 import * as sqlite3 from 'sqlite3'
 import { Writable } from 'stream'
 import { v4 as uuid } from 'uuid'
-import { InterpretedBallot, MarkInfo } from './interpreter'
+import { MarkInfo, PageInterpretation } from './interpreter'
 import {
   AdjudicationStatus,
   BatchInfo,
@@ -416,17 +416,17 @@ export default class Store {
     batchId: string,
     originalFilename: string,
     normalizedFilename: string,
-    interpreted: InterpretedBallot
+    interpretation: PageInterpretation
   ): Promise<string> {
-    const cvr = 'cvr' in interpreted ? interpreted.cvr : undefined
+    const cvr = 'cvr' in interpretation ? interpretation.cvr : undefined
     const markInfo =
-      'markInfo' in interpreted ? interpreted.markInfo : undefined
+      'markInfo' in interpretation ? interpretation.markInfo : undefined
     const metadata =
-      'metadata' in interpreted ? interpreted.metadata : undefined
+      'metadata' in interpretation ? interpretation.metadata : undefined
 
     const canBeAdjudicated =
-      interpreted.type === 'InterpretedHmpbBallot' ||
-      interpreted.type === 'UninterpretedHmpbBallot'
+      interpretation.type === 'InterpretedHmpbPage' ||
+      interpretation.type === 'UninterpretedHmpbPage'
     let requiresAdjudication = false
     let adjudicationInfo: AdjudicationInfo | undefined
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -412,6 +412,7 @@ export default class Store {
    * Adds a ballot to an existing batch.
    */
   public async addBallot(
+    ballotId: string,
     batchId: string,
     originalFilename: string,
     normalizedFilename: string,
@@ -491,12 +492,11 @@ export default class Store {
     }
 
     try {
-      const id = uuid()
       await this.dbRunAsync(
         `insert into ballots
           (id, batch_id, original_filename, normalized_filename, cvr_json, marks_json, metadata_json, requires_adjudication, adjudication_info_json)
           values (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        id,
+        ballotId,
         batchId,
         originalFilename,
         normalizedFilename,

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,40 @@ export interface Dictionary<T> {
 
 export type NonEmptyArray<T> = [T, ...T[]]
 
+export type Result<E, T> = ErrorResult<E> | ValueResult<T>
+export interface ErrorResult<E> {
+  error: E
+}
+export interface ValueResult<T> {
+  value: T
+}
+
+export function isValueResult<E, T>(
+  result: Result<E, T>
+): result is ValueResult<T> {
+  return 'value' in result
+}
+
+export function isErrorResult<E, T>(
+  result: Result<E, T>
+): result is ErrorResult<E> {
+  return 'error' in result
+}
+
+export function resultValue<E, T>(result: Result<E, T>): T {
+  if (isErrorResult(result)) {
+    throw new TypeError('cannot extract value from error result')
+  }
+  return result.value
+}
+
+export function resultError<E, T>(result: Result<E, T>): E {
+  if (isValueResult(result)) {
+    throw new TypeError('cannot extract error from value result')
+  }
+  return result.error
+}
+
 export interface CastVoteRecord
   extends Dictionary<string | string[] | boolean | number | BallotLocales> {
   _precinctId: string

--- a/src/util/makeTemporaryBallotImportImageDirectories.ts
+++ b/src/util/makeTemporaryBallotImportImageDirectories.ts
@@ -4,7 +4,7 @@ import * as tmp from 'tmp'
 import type { Options } from '../importer'
 
 export interface TemporaryBallotImportImageDirectories {
-  paths: Pick<Options, 'ballotImagesPath' | 'importedBallotImagesPath'>
+  paths: Pick<Options, 'scannedImagesPath' | 'importedImagesPath'>
   remove(): void
 }
 
@@ -12,8 +12,8 @@ export default function makeTemporaryBallotImportImageDirectories(): TemporaryBa
   const root = tmp.dirSync({ tmpdir: path.join(__dirname, '../../tmp') })
   return {
     paths: {
-      ballotImagesPath: path.join(root.name, 'to-import'),
-      importedBallotImagesPath: path.join(root.name, 'imported'),
+      scannedImagesPath: path.join(root.name, 'to-import'),
+      importedImagesPath: path.join(root.name, 'imported'),
     },
     remove: (): void => fs.removeSync(root.name),
   }

--- a/test/fixtures/emptyImage.ts
+++ b/test/fixtures/emptyImage.ts
@@ -1,7 +1,0 @@
-const EMPTY_IMAGE: ImageData = {
-  width: 0,
-  height: 0,
-  data: Uint8ClampedArray.of(),
-}
-
-export default EMPTY_IMAGE


### PR DESCRIPTION
Previously we had a lot of cases where we ignored the results of importing a file. Now, we pull in all of them and keep track of how it failed.