### PR TITLE
refactor: consolidate adjudication into page interpretation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 *.db
-*.db.digest
+*.db.*
 tmp
 !tmp/.gitkeep
 hmpb-templates

--- a/schema.sql
+++ b/schema.sql
@@ -19,9 +19,11 @@ create table ballots (
   -- @type {MarksByContestId}
   adjudication_json text,
 
-  -- Does this page _currently_ require adjudication? Updated as the page is
-  -- adjudicated.
+  -- Did this page require adjudication? This value should never be updated.
   requires_adjudication boolean,
+
+  -- When adjudication is finished, this value is updated to the current time.
+  finished_adjudication_at datetime,
 
   created_at datetime default current_timestamp not null,
 

--- a/schema.sql
+++ b/schema.sql
@@ -9,10 +9,20 @@ create table ballots (
   batch_id varchar(36),
   original_filename text unique,
   normalized_filename text unique,
+
+  -- Original interpretation of the page. This value should never be updated.
+  -- @type {PageInterpretation}
   interpretation_json text not null,
+
+  -- Changes made in adjudication, should be applied on top of the original CVR.
+  -- Updated as the page is adjudicated.
+  -- @type {MarksByContestId}
   adjudication_json text,
-  adjudication_info_json text,
+
+  -- Does this page _currently_ require adjudication? Updated as the page is
+  -- adjudicated.
   requires_adjudication boolean,
+
   created_at datetime default current_timestamp not null,
 
   foreign key (batch_id)

--- a/src/interpreter.test.ts
+++ b/src/interpreter.test.ts
@@ -8,7 +8,8 @@ import SummaryBallotInterpreter, {
   InterpretedHmpbPage,
   UninterpretedHmpbPage,
 } from './interpreter'
-import { resultValue, resultError } from './types'
+import { DefaultMarkThresholds } from './store'
+import { resultError, resultValue } from './types'
 import pdfToImages from './util/pdfToImages'
 
 const sampleBallotImagesPath = join(__dirname, '..', 'sample-ballot-images/')
@@ -203,7 +204,10 @@ test('interprets marks in PNG ballots', async () => {
     const ballotImagePath = join(choctaw2020FixturesRoot, 'filled-in-p1.png')
     const cvr = ((
       await interpreter.interpretFile({
-        election: choctaw2020Election,
+        election: {
+          markThresholds: DefaultMarkThresholds,
+          ...choctaw2020Election,
+        },
         ballotImagePath,
         ballotImageFile: await readFile(ballotImagePath),
       })
@@ -248,7 +252,10 @@ test('interprets marks in PNG ballots', async () => {
     const ballotImagePath = join(choctaw2020FixturesRoot, 'filled-in-p2.png')
     const cvr = ((
       await interpreter.interpretFile({
-        election: choctaw2020Election,
+        election: {
+          markThresholds: DefaultMarkThresholds,
+          ...choctaw2020Election,
+        },
         ballotImagePath,
         ballotImageFile: await readFile(ballotImagePath),
       })

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -238,6 +238,14 @@ test('GET /scan/hmpb/ballot/:ballotId', async () => {
         pageCount: 1,
         locales: { primary: 'en-US' },
       },
+      adjudicationInfo: {
+        requiresAdjudication: false,
+        enabledReasons: [
+          AdjudicationReason.UninterpretableBallot,
+          AdjudicationReason.MarginalMark,
+        ],
+        allReasonInfos: [],
+      },
     }
   )
   await store.finishBatch(batchId)
@@ -259,6 +267,7 @@ test('GET /scan/hmpb/ballot/:ballotId', async () => {
       contests: [],
       layout: [],
       adjudicationInfo: {
+        requiresAdjudication: false,
         enabledReasons: [
           AdjudicationReason.UninterpretableBallot,
           AdjudicationReason.MarginalMark,
@@ -330,6 +339,21 @@ test('PATCH /scan/hmpb/ballot/:ballotId', async () => {
         pageCount: 1,
         locales: { primary: 'en-US' },
       },
+      adjudicationInfo: {
+        requiresAdjudication: false,
+        enabledReasons: [
+          AdjudicationReason.UninterpretableBallot,
+          AdjudicationReason.MarginalMark,
+        ],
+        allReasonInfos: [
+          {
+            type: AdjudicationReason.Undervote,
+            contestId: yesnoContest.id,
+            expected: 1,
+            optionIds: [],
+          },
+        ],
+      },
     }
   )
   await store.finishBatch(batchId)
@@ -360,6 +384,7 @@ test('PATCH /scan/hmpb/ballot/:ballotId', async () => {
     contests: [],
     layout: [],
     adjudicationInfo: {
+      requiresAdjudication: false,
       enabledReasons: [
         AdjudicationReason.UninterpretableBallot,
         AdjudicationReason.MarginalMark,
@@ -401,6 +426,7 @@ test('PATCH /scan/hmpb/ballot/:ballotId', async () => {
     contests: [],
     layout: [],
     adjudicationInfo: {
+      requiresAdjudication: false,
       enabledReasons: [
         AdjudicationReason.UninterpretableBallot,
         AdjudicationReason.MarginalMark,
@@ -451,6 +477,11 @@ test('GET /scan/hmpb/ballot/:ballotId/image', async () => {
       markInfo: {
         ballotSize: { width: 0, height: 0 },
         marks: [],
+      },
+      adjudicationInfo: {
+        requiresAdjudication: false,
+        enabledReasons: [],
+        allReasonInfos: [],
       },
     }
   )

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -227,6 +227,26 @@ test('adjudication', async () => {
         pageCount: 2,
         locales: { primary: 'en-US' },
       },
+      adjudicationInfo: {
+        requiresAdjudication: true,
+        enabledReasons: [
+          AdjudicationReason.UninterpretableBallot,
+          AdjudicationReason.MarginalMark,
+        ],
+        allReasonInfos: [
+          {
+            type: AdjudicationReason.MarginalMark,
+            contestId: candidateContest.id,
+            optionId: candidateOption.id,
+          },
+          {
+            type: AdjudicationReason.Undervote,
+            contestId: candidateContest.id,
+            expected: 1,
+            optionIds: [],
+          },
+        ],
+      },
     }
   )
   await store.finishBatch(batchId)
@@ -238,6 +258,7 @@ test('adjudication', async () => {
         [yesnoContest.id]: { [yesnoOption]: MarkStatus.Marked },
       },
       adjudicationInfo: {
+        requiresAdjudication: true,
         enabledReasons: [
           AdjudicationReason.UninterpretableBallot,
           AdjudicationReason.MarginalMark,
@@ -271,6 +292,7 @@ test('adjudication', async () => {
         [yesnoContest.id]: { [yesnoOption]: MarkStatus.Unmarked },
       },
       adjudicationInfo: {
+        requiresAdjudication: true,
         enabledReasons: [
           AdjudicationReason.UninterpretableBallot,
           AdjudicationReason.MarginalMark,

--- a/src/types/ballot-review.ts
+++ b/src/types/ballot-review.ts
@@ -38,6 +38,7 @@ export interface BallotInfo {
 }
 
 export interface AdjudicationInfo {
+  requiresAdjudication: boolean
   enabledReasons: readonly AdjudicationReason[]
   allReasonInfos: readonly AdjudicationReasonInfo[]
 }


### PR DESCRIPTION
This moves the initial code to determine whether adjudication is required out of `Store` and into `Interpreter`, which feels better.