### PR TITLE
feat: read binary QR codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "dependencies": {
     "@types/sharp": "^0.25.1",
-    "@votingworks/ballot-encoder": "^3.0.0",
-    "@votingworks/hmpb-interpreter": "^4.2.0",
+    "@votingworks/ballot-encoder": "^4.0.0",
+    "@votingworks/hmpb-interpreter": "^5.1.0",
     "@votingworks/qrdetect": "^1.0.1",
     "busboy": "^0.3.1",
     "canvas": "^2.6.1",
@@ -78,7 +78,8 @@
     "supertest": "^4.0.2",
     "ts-jest": "^26.0.0",
     "ts-node": "^8.10.1",
-    "typescript": "^3.9.3"
+    "typescript": "^3.9.3",
+    "zod": "^1.11.4"
   },
   "engines": {
     "node": ">= 12"

--- a/schema.sql
+++ b/schema.sql
@@ -48,19 +48,10 @@ create table configs (
 
 create table hmpb_templates (
   id varchar(36) primary key,
-  pdf blob,
-  locales varchar(255),
-  ballot_style_id varchar(255),
-  precinct_id varchar(255),
-  is_test_ballot boolean,
+  pdf blob not null,
+  -- @type {BallotMetadata}
+  metadata_json text not null,
   -- @type {SerializableBallotPageLayout[]}
-  layouts_json text,
+  layouts_json text not null,
   created_at datetime default current_timestamp not null
-);
-
-create unique index hmpb_templates_idx on hmpb_templates (
-  locales,
-  ballot_style_id,
-  precinct_id,
-  is_test_ballot
 );

--- a/src/buildCastVoteRecord.test.ts
+++ b/src/buildCastVoteRecord.test.ts
@@ -3,6 +3,7 @@ import {
   getBallotStyle,
   getContests,
   vote,
+  BallotType,
 } from '@votingworks/ballot-encoder'
 import election from '../test/fixtures/2020-choctaw/election'
 import { buildCastVoteRecord } from './buildCastVoteRecord'
@@ -22,9 +23,12 @@ test('generates a CVR from a completed BMD ballot', () => {
           type: 'InterpretedBmdPage',
           ballotId,
           metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Standard,
             ballotStyleId,
             precinctId,
-            isTestBallot: false,
+            isTestMode: false,
           },
           votes: vote(contests, {
             '1': '1',
@@ -51,7 +55,9 @@ test('generates a CVR from a completed BMD ballot', () => {
       "4": Array [],
       "_ballotId": "abcdefg",
       "_ballotStyleId": "1",
-      "_locales": undefined,
+      "_locales": Object {
+        "primary": "en-US",
+      },
       "_precinctId": "6522",
       "_scannerId": "000",
       "_testBallot": false,
@@ -80,11 +86,13 @@ test('generates a CVR from a completed HMPB page', () => {
           type: 'InterpretedHmpbPage',
           ballotId: 'abcdefg',
           metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Standard,
             ballotStyleId,
             precinctId,
-            isTestBallot: false,
+            isTestMode: false,
             pageNumber: 1,
-            pageCount: 2,
           },
           markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
           adjudicationInfo: {
@@ -104,11 +112,13 @@ test('generates a CVR from a completed HMPB page', () => {
           type: 'InterpretedHmpbPage',
           ballotId: 'abcdefg',
           metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Standard,
             ballotStyleId,
             precinctId,
-            isTestBallot: false,
+            isTestMode: false,
             pageNumber: 2,
-            pageCount: 2,
           },
           markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
           adjudicationInfo: {
@@ -133,7 +143,9 @@ test('generates a CVR from a completed HMPB page', () => {
       ],
       "_ballotId": "abcdefg",
       "_ballotStyleId": "1",
-      "_locales": undefined,
+      "_locales": Object {
+        "primary": "en-US",
+      },
       "_pageNumbers": Array [
         1,
         2,
@@ -163,11 +175,13 @@ test('generates a CVR from an adjudicated HMPB page', () => {
           type: 'InterpretedHmpbPage',
           ballotId: 'abcdefg',
           metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Standard,
             ballotStyleId,
             precinctId,
-            isTestBallot: false,
+            isTestMode: false,
             pageNumber: 2,
-            pageCount: 2,
           },
           markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
           adjudicationInfo: {
@@ -198,11 +212,13 @@ test('generates a CVR from an adjudicated HMPB page', () => {
           type: 'InterpretedHmpbPage',
           ballotId: 'abcdefg',
           metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Standard,
             ballotStyleId,
             precinctId,
-            isTestBallot: false,
+            isTestMode: false,
             pageNumber: 1,
-            pageCount: 2,
           },
           markInfo: { marks: [], ballotSize: { width: 1, height: 1 } },
           adjudicationInfo: {
@@ -228,7 +244,9 @@ test('generates a CVR from an adjudicated HMPB page', () => {
       ],
       "_ballotId": "abcdefg",
       "_ballotStyleId": "1",
-      "_locales": undefined,
+      "_locales": Object {
+        "primary": "en-US",
+      },
       "_pageNumbers": Array [
         1,
         2,
@@ -254,11 +272,13 @@ test('fails to generate a CVR from an invalid HMPB sheet with two pages having t
         interpretation: {
           type: 'InterpretedHmpbPage',
           metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Standard,
             ballotStyleId,
             precinctId,
-            isTestBallot: false,
+            isTestMode: false,
             pageNumber: 1,
-            pageCount: 2,
           },
           adjudicationInfo: {
             requiresAdjudication: false,
@@ -276,11 +296,13 @@ test('fails to generate a CVR from an invalid HMPB sheet with two pages having t
         interpretation: {
           type: 'UninterpretedHmpbPage',
           metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Standard,
             ballotStyleId,
             precinctId,
-            isTestBallot: false,
+            isTestMode: false,
             pageNumber: 1,
-            pageCount: 2,
           },
         },
       },
@@ -301,11 +323,13 @@ test('fails to generate a CVR from an invalid HMPB sheet with two non-consecutiv
         interpretation: {
           type: 'InterpretedHmpbPage',
           metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Standard,
             ballotStyleId,
             precinctId,
-            isTestBallot: false,
+            isTestMode: false,
             pageNumber: 1,
-            pageCount: 2,
           },
           adjudicationInfo: {
             requiresAdjudication: false,
@@ -323,64 +347,19 @@ test('fails to generate a CVR from an invalid HMPB sheet with two non-consecutiv
         interpretation: {
           type: 'UninterpretedHmpbPage',
           metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Standard,
             ballotStyleId,
             precinctId,
-            isTestBallot: false,
+            isTestMode: false,
             pageNumber: 3,
-            pageCount: 2,
           },
         },
       },
     ])
   ).toThrowError(
     'expected a sheet to have consecutive page numbers, but got front=1 back=3'
-  )
-})
-
-test('fails to generate a CVR from an invalid HMPB sheet with different page counts', () => {
-  const ballotId = 'abcdefg'
-  const ballotStyleId = '1'
-  const precinctId = '6522'
-
-  expect(() =>
-    buildCastVoteRecord(ballotId, election, [
-      {
-        interpretation: {
-          type: 'InterpretedHmpbPage',
-          metadata: {
-            ballotStyleId,
-            precinctId,
-            isTestBallot: false,
-            pageNumber: 1,
-            pageCount: 2,
-          },
-          adjudicationInfo: {
-            requiresAdjudication: false,
-            enabledReasons: [],
-            allReasonInfos: [],
-          },
-          markInfo: {
-            marks: [],
-            ballotSize: { width: 1, height: 1 },
-          },
-          votes: {},
-        },
-      },
-      {
-        interpretation: {
-          type: 'UninterpretedHmpbPage',
-          metadata: {
-            ballotStyleId,
-            precinctId,
-            isTestBallot: false,
-            pageNumber: 2,
-            pageCount: 3,
-          },
-        },
-      },
-    ])
-  ).toThrowError(
-    'expected a sheet to have the same page count, but got front=2 back=3'
   )
 })
 
@@ -394,11 +373,13 @@ test('fails to generate a CVR from an invalid HMPB sheet with different ballot s
         interpretation: {
           type: 'InterpretedHmpbPage',
           metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Standard,
             ballotStyleId: '1',
             precinctId,
-            isTestBallot: false,
+            isTestMode: false,
             pageNumber: 1,
-            pageCount: 2,
           },
           adjudicationInfo: {
             requiresAdjudication: false,
@@ -416,11 +397,13 @@ test('fails to generate a CVR from an invalid HMPB sheet with different ballot s
         interpretation: {
           type: 'UninterpretedHmpbPage',
           metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Standard,
             ballotStyleId: '2',
             precinctId,
-            isTestBallot: false,
+            isTestMode: false,
             pageNumber: 2,
-            pageCount: 2,
           },
         },
       },
@@ -440,11 +423,13 @@ test('fails to generate a CVR from an invalid HMPB sheet with different precinct
         interpretation: {
           type: 'InterpretedHmpbPage',
           metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Standard,
             ballotStyleId,
             precinctId: '6522',
-            isTestBallot: false,
+            isTestMode: false,
             pageNumber: 1,
-            pageCount: 2,
           },
           adjudicationInfo: {
             requiresAdjudication: false,
@@ -462,11 +447,13 @@ test('fails to generate a CVR from an invalid HMPB sheet with different precinct
         interpretation: {
           type: 'UninterpretedHmpbPage',
           metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Standard,
             ballotStyleId,
             precinctId: '6523',
-            isTestBallot: false,
+            isTestMode: false,
             pageNumber: 2,
-            pageCount: 2,
           },
         },
       },
@@ -487,12 +474,13 @@ test('generates a CVR from an adjudicated uninterpreted HMPB page', () => {
         interpretation: {
           type: 'InterpretedHmpbPage',
           metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Standard,
             ballotStyleId,
             precinctId,
-            isTestBallot: false,
+            isTestMode: false,
             pageNumber: 1,
-            pageCount: 2,
-            locales: { primary: 'en-US' },
           },
           adjudicationInfo: {
             requiresAdjudication: false,
@@ -522,12 +510,13 @@ test('generates a CVR from an adjudicated uninterpreted HMPB page', () => {
         interpretation: {
           type: 'UninterpretedHmpbPage',
           metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Standard,
             ballotStyleId,
             precinctId,
-            isTestBallot: false,
+            isTestMode: false,
             pageNumber: 2,
-            pageCount: 2,
-            locales: { primary: 'en-US' },
           },
         },
         contestIds: ['initiative-65'],
@@ -587,10 +576,12 @@ test('fails to generate CVRs from invalid test mode pages', () => {
         interpretation: {
           type: 'InvalidTestModePage',
           metadata: {
+            locales: { primary: 'en-US' },
+            electionHash: '',
+            ballotType: BallotType.Standard,
             ballotStyleId,
             precinctId,
-            isTestBallot: false,
-            locales: { primary: 'en-US' },
+            isTestMode: false,
           },
         },
       },

--- a/src/buildCastVoteRecord.ts
+++ b/src/buildCastVoteRecord.ts
@@ -34,7 +34,7 @@ export function buildCastVoteRecordMetadataEntries(
     _ballotStyleId: metadata.ballotStyleId,
     _precinctId: metadata.precinctId,
     _scannerId: getMachineId(),
-    _testBallot: metadata.isTestBallot,
+    _testBallot: metadata.isTestMode,
     _locales: metadata.locales,
   }
 }
@@ -154,15 +154,6 @@ export function buildCastVoteRecordFromHmpbPage(
   ) {
     throw new Error(
       `expected a sheet to have the same precinct, but got front=${front.interpretation.metadata.precinctId} back=${back.interpretation.metadata.precinctId}`
-    )
-  }
-
-  if (
-    front.interpretation.metadata.pageCount !==
-    back.interpretation.metadata.pageCount
-  ) {
-    throw new Error(
-      `expected a sheet to have the same page count, but got front=${front.interpretation.metadata.pageCount} back=${back.interpretation.metadata.pageCount}`
     )
   }
 

--- a/src/interpreter.test.ts
+++ b/src/interpreter.test.ts
@@ -73,7 +73,12 @@ test('extracts votes encoded in a QR code', async () => {
       "ballotId": "r6UYR4t7hEFMz8QlMWf1Sw",
       "metadata": Object {
         "ballotStyleId": "12",
-        "isTestBallot": false,
+        "ballotType": 0,
+        "electionHash": "",
+        "isTestMode": false,
+        "locales": Object {
+          "primary": "en-US",
+        },
         "precinctId": "23",
       },
       "type": "InterpretedBmdPage",
@@ -1571,12 +1576,13 @@ test('interprets marks on an upside-down HMPB', async () => {
       },
       "metadata": Object {
         "ballotStyleId": "12",
-        "isTestBallot": false,
+        "ballotType": 0,
+        "electionHash": "",
+        "isTestMode": false,
         "locales": Object {
           "primary": "en-US",
           "secondary": "es-US",
         },
-        "pageCount": 5,
         "pageNumber": 1,
         "precinctId": "23",
       },
@@ -2487,11 +2493,12 @@ test('interprets marks in PNG ballots', async () => {
         },
         "metadata": Object {
           "ballotStyleId": "1",
-          "isTestBallot": false,
+          "ballotType": 0,
+          "electionHash": "",
+          "isTestMode": false,
           "locales": Object {
             "primary": "en-US",
           },
-          "pageCount": 2,
           "pageNumber": 1,
           "precinctId": "6526",
         },
@@ -2710,11 +2717,12 @@ test('interprets marks in PNG ballots', async () => {
         },
         "metadata": Object {
           "ballotStyleId": "1",
-          "isTestBallot": false,
+          "ballotType": 0,
+          "electionHash": "",
+          "isTestMode": false,
           "locales": Object {
             "primary": "en-US",
           },
-          "pageCount": 2,
           "pageNumber": 2,
           "precinctId": "6526",
         },
@@ -2764,12 +2772,13 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
     Object {
       "metadata": Object {
         "ballotStyleId": "12",
-        "isTestBallot": false,
+        "ballotType": 0,
+        "electionHash": "",
+        "isTestMode": false,
         "locales": Object {
           "primary": "en-US",
           "secondary": "es-US",
         },
-        "pageCount": 5,
         "pageNumber": 3,
         "precinctId": "23",
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,9 @@
 import {
   BallotStyle,
   Contest,
-  Precinct,
+  Election,
   MarkThresholds,
+  Precinct,
 } from '@votingworks/ballot-encoder'
 import {
   BallotLocales,
@@ -12,7 +13,7 @@ import {
   BallotTargetMark,
 } from '@votingworks/hmpb-interpreter'
 import { MarkInfo, PageInterpretation } from './interpreter'
-import { MarkStatus, MarksByContestId } from './types/ballot-review'
+import { MarksByContestId, MarkStatus } from './types/ballot-review'
 
 export interface Dictionary<T> {
   [key: string]: T | undefined
@@ -69,6 +70,12 @@ export interface PageInterpretationWithAdjudication<
   interpretation: T
   contestIds?: readonly string[]
   adjudication?: MarksByContestId
+}
+
+export interface ElectionDefinition {
+  election: Election
+  electionData: string
+  electionHash: string
 }
 
 export interface CastVoteRecord
@@ -131,10 +138,7 @@ export interface HmpbTemplateInfo {
   pageCount: number
 }
 
-export type BallotMetadata = Omit<
-  BallotPageMetadata,
-  'pageNumber' | 'pageCount'
->
+export type BallotMetadata = Omit<BallotPageMetadata, 'pageNumber' | 'ballotId'>
 
 export type SerializableBallotPageLayout = Omit<
   BallotPageLayout,

--- a/src/util/electionDefinition.ts
+++ b/src/util/electionDefinition.ts
@@ -1,0 +1,62 @@
+import { Election, parseElection } from '@votingworks/ballot-encoder'
+import { ElectionDefinition } from '../types'
+import { createHash } from 'crypto'
+import type * as z from 'zod'
+
+export function hash(election: Election): string
+export function hash(electionData: string): string
+export function hash(election: Election | string): string {
+  return createHash('sha256')
+    .update(typeof election === 'string' ? election : JSON.stringify(election))
+    .digest('hex')
+}
+
+export function fromElection(election: Election): ElectionDefinition {
+  const electionData = JSON.stringify(election)
+  const electionHash = hash(electionData)
+  return { election, electionData, electionHash }
+}
+
+export enum ValidationErrorType {
+  JSONMismatch = 'JSONMismatch',
+  HashMismatch = 'HashMismatch',
+  InvalidSchema = 'InvalidSchema',
+}
+
+export type ValidationError =
+  | { type: ValidationErrorType.JSONMismatch; actual: string; expected: string }
+  | { type: ValidationErrorType.HashMismatch; actual: string; expected: string }
+  | { type: ValidationErrorType.InvalidSchema; error: z.ZodError }
+
+export function* validate(
+  electionDefinition: ElectionDefinition
+): Generator<ValidationError> {
+  const actualJSON = electionDefinition.electionData
+  const expectedJSON = JSON.stringify(electionDefinition.election)
+  if (expectedJSON !== electionDefinition.electionData) {
+    yield {
+      type: ValidationErrorType.JSONMismatch,
+      actual: actualJSON,
+      expected: expectedJSON,
+    }
+  }
+
+  const actualHash = electionDefinition.electionHash
+  const expectedHash = hash(electionDefinition.election)
+  if (expectedHash !== actualHash) {
+    yield {
+      type: ValidationErrorType.HashMismatch,
+      actual: actualHash,
+      expected: expectedHash,
+    }
+  }
+
+  try {
+    parseElection(electionDefinition.election)
+  } catch (error) {
+    yield {
+      type: ValidationErrorType.InvalidSchema,
+      error,
+    }
+  }
+}

--- a/src/util/getBallotPageContests.test.ts
+++ b/src/util/getBallotPageContests.test.ts
@@ -1,4 +1,8 @@
-import { getBallotStyle, getContests } from '@votingworks/ballot-encoder'
+import {
+  BallotType,
+  getBallotStyle,
+  getContests,
+} from '@votingworks/ballot-encoder'
 import { BallotPageMetadata } from '@votingworks/hmpb-interpreter'
 import election from '../../test/fixtures/state-of-hamilton/election'
 import { SerializableBallotPageLayout } from '../types'
@@ -8,10 +12,11 @@ function metadataForPage(pageNumber: number): BallotPageMetadata {
   return {
     ballotStyleId: '12',
     precinctId: '23',
-    isTestBallot: false,
+    isTestMode: false,
     pageNumber,
-    pageCount: 5,
     locales: { primary: 'en-US', secondary: 'es-US' },
+    ballotType: BallotType.Standard,
+    electionHash: '',
   }
 }
 test('gets contests broken across pages according to the layout', () => {

--- a/test/fixtures/2020-choctaw/ballot-p1-metadata.json
+++ b/test/fixtures/2020-choctaw/ballot-p1-metadata.json
@@ -4,7 +4,7 @@
   },
   "ballotStyleId": "1",
   "precinctId": "6526",
-  "isTestBallot": false,
+  "isTestMode": false,
   "pageCount": 2,
   "pageNumber": 1
 }

--- a/test/fixtures/2020-choctaw/ballot-p2-metadata.json
+++ b/test/fixtures/2020-choctaw/ballot-p2-metadata.json
@@ -4,7 +4,7 @@
   },
   "ballotStyleId": "1",
   "precinctId": "6526",
-  "isTestBallot": false,
+  "isTestMode": false,
   "pageCount": 2,
   "pageNumber": 2
 }

--- a/test/fixtures/state-of-hamilton/filled-in-dual-language-p1-metadata.json
+++ b/test/fixtures/state-of-hamilton/filled-in-dual-language-p1-metadata.json
@@ -1,7 +1,7 @@
 {
   "ballotStyleId": "12",
-  "isTestBallot": false,
-  "locales": {"primary": "en-US", "secondary": "es-US"},
+  "isTestMode": false,
+  "locales": { "primary": "en-US", "secondary": "es-US" },
   "pageCount": 5,
   "pageNumber": 1,
   "precinctId": "23"

--- a/test/fixtures/state-of-hamilton/filled-in-dual-language-p2-metadata.json
+++ b/test/fixtures/state-of-hamilton/filled-in-dual-language-p2-metadata.json
@@ -1,7 +1,7 @@
 {
   "ballotStyleId": "12",
-  "isTestBallot": false,
-  "locales": {"primary": "en-US", "secondary": "es-US"},
+  "isTestMode": false,
+  "locales": { "primary": "en-US", "secondary": "es-US" },
   "pageCount": 5,
   "pageNumber": 2,
   "precinctId": "23"

--- a/test/fixtures/state-of-hamilton/filled-in-dual-language-p3-metadata.json
+++ b/test/fixtures/state-of-hamilton/filled-in-dual-language-p3-metadata.json
@@ -1,7 +1,7 @@
 {
   "ballotStyleId": "12",
-  "isTestBallot": false,
-  "locales": {"primary": "en-US", "secondary": "es-US"},
+  "isTestMode": false,
+  "locales": { "primary": "en-US", "secondary": "es-US" },
   "pageCount": 5,
   "pageNumber": 3,
   "precinctId": "23"

--- a/test/fixtures/state-of-hamilton/filled-in-dual-language-p4-metadata.json
+++ b/test/fixtures/state-of-hamilton/filled-in-dual-language-p4-metadata.json
@@ -1,7 +1,7 @@
 {
   "ballotStyleId": "12",
-  "isTestBallot": false,
-  "locales": {"primary": "en-US", "secondary": "es-US"},
+  "isTestMode": false,
+  "locales": { "primary": "en-US", "secondary": "es-US" },
   "pageCount": 5,
   "pageNumber": 4,
   "precinctId": "23"

--- a/test/fixtures/state-of-hamilton/filled-in-dual-language-p5-metadata.json
+++ b/test/fixtures/state-of-hamilton/filled-in-dual-language-p5-metadata.json
@@ -1,7 +1,7 @@
 {
   "ballotStyleId": "12",
-  "isTestBallot": false,
-  "locales": {"primary": "en-US", "secondary": "es-US"},
+  "isTestMode": false,
+  "locales": { "primary": "en-US", "secondary": "es-US" },
   "pageCount": 5,
   "pageNumber": 5,
   "precinctId": "23"

--- a/yarn.lock
+++ b/yarn.lock
@@ -959,20 +959,20 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
-"@votingworks/ballot-encoder@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@votingworks/ballot-encoder/-/ballot-encoder-3.0.0.tgz#c82ce28b184ff3828d393b11928517021a6ce855"
-  integrity sha512-IK8wkd0uT6XSjlakvYOthzbEC701ycVU0C050nudNL3+TTCCa6Xtz2x69xOXVedCn0fCo2vrJ5c8OveoFqeFPg==
+"@votingworks/ballot-encoder@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@votingworks/ballot-encoder/-/ballot-encoder-4.0.0.tgz#f87152e962110e56c37985547e702f39bc8639f8"
+  integrity sha512-sC3m6J6MuUgvb5qq5avppaimCKX0wLFkoFakH1B1MM8F91Sx3Jq5GqvkNuDgs8iRPgTOAJS83ayKxSCPsq9NeA==
   dependencies:
     "@antongolub/iso8601" "^1.2.1"
     zod "^1.7.1"
 
-"@votingworks/hmpb-interpreter@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@votingworks/hmpb-interpreter/-/hmpb-interpreter-4.2.0.tgz#1b7f02fe442e027828bc960760bb407da614e04f"
-  integrity sha512-opkUJ/fw1wCqsDELVoDfAMhMcLZY91QSOpilZFLMouCAH2dRRBpN+RAzIwWVhCn92COIGBPVeTRl0l5nOZ0x1Q==
+"@votingworks/hmpb-interpreter@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@votingworks/hmpb-interpreter/-/hmpb-interpreter-5.1.0.tgz#ddcf45d95ecc01b867cea9e83efb2bc4e485b025"
+  integrity sha512-Vzm58GrTxnW02RwT4qHpECWChYVWPTRslmqceS7DCrRaqEn5uQEC2tjdI2juepJfm9m0RX5dEWsC8qyG5aYJGA==
   dependencies:
-    "@votingworks/ballot-encoder" "^3.0.0"
+    "@votingworks/ballot-encoder" "^4.0.0"
     canvas "^2.6.1"
     chalk "^4.0.0"
     debug "^4.1.1"
@@ -6657,6 +6657,11 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+
+zod@^1.11.4:
+  version "1.11.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-1.11.4.tgz#0de8f2e62f6bbf16a4f1a28ca2708b2ff8465fd1"
+  integrity sha512-KArP+E2Nl/46qkC1yFd0mUMg/6ZDZKyjpaKRA1Vm2+MZH7wmLFYBCDZKTU666LmZHcGsm5EZTDIMsQB+o99iWg==
 
 zod@^1.7.1:
   version "1.7.2"


### PR DESCRIPTION
This updates hmpb-interpreter and ballot-encoder to support reading sheets with binary QR codes.