### PR TITLE
style: use type annotations rather than casting

### DIFF
--- a/src/interpreter.test.ts
+++ b/src/interpreter.test.ts
@@ -6,8 +6,8 @@ import stateOfHamiltonElection from '../test/fixtures/state-of-hamilton/election
 import SummaryBallotInterpreter, {
   getBallotImageData,
   InterpretedHmpbPage,
-  UninterpretedHmpbPage,
   sheetRequiresAdjudication,
+  UninterpretedHmpbPage,
 } from './interpreter'
 import { DefaultMarkThresholds } from './store'
 import { resultError, resultValue } from './types'
@@ -2788,7 +2788,7 @@ test('returns metadata if the QR code is readable but the HMPB ballot is not', a
   `)
 })
 
-const pageInterpretationBoilerplate = {
+const pageInterpretationBoilerplate: InterpretedHmpbPage = {
   type: 'InterpretedHmpbPage',
   metadata: {
     ballotStyleId: '12',
@@ -2809,26 +2809,29 @@ const pageInterpretationBoilerplate = {
     marks: [],
   },
   votes: {},
+  adjudicationInfo: {
+    allReasonInfos: [],
+    enabledReasons: [],
+    requiresAdjudication: false,
+  },
 }
 
 test('sheetRequiresAdjudication triggers if front or back requires adjudication', async () => {
-  const sideYes = {
+  const sideYes: InterpretedHmpbPage = {
     ...pageInterpretationBoilerplate,
     adjudicationInfo: {
+      ...pageInterpretationBoilerplate.adjudicationInfo,
       requiresAdjudication: true,
-      enabledReasons: [],
-      allReasonInfos: [],
     },
-  } as InterpretedHmpbPage
+  }
 
-  const sideNo = {
+  const sideNo: InterpretedHmpbPage = {
     ...pageInterpretationBoilerplate,
     adjudicationInfo: {
+      ...pageInterpretationBoilerplate.adjudicationInfo,
       requiresAdjudication: false,
-      enabledReasons: [],
-      allReasonInfos: [],
     },
-  } as InterpretedHmpbPage
+  }
 
   expect(sheetRequiresAdjudication([sideYes, sideNo])).toBe(true)
   expect(sheetRequiresAdjudication([sideNo, sideYes])).toBe(true)
@@ -2837,7 +2840,7 @@ test('sheetRequiresAdjudication triggers if front or back requires adjudication'
 })
 
 test('sheetRequiresAdjudication triggers only if both sides are blank ballot', async () => {
-  const sideBlank = {
+  const sideBlank: InterpretedHmpbPage = {
     ...pageInterpretationBoilerplate,
     adjudicationInfo: {
       requiresAdjudication: true,
@@ -2847,16 +2850,16 @@ test('sheetRequiresAdjudication triggers only if both sides are blank ballot', a
       ],
       allReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
     },
-  } as InterpretedHmpbPage
+  }
 
-  const sideNotBlank = {
+  const sideNotBlank: InterpretedHmpbPage = {
     ...pageInterpretationBoilerplate,
     adjudicationInfo: {
       requiresAdjudication: false,
       enabledReasons: [],
       allReasonInfos: [],
     },
-  } as InterpretedHmpbPage
+  }
 
   expect(sheetRequiresAdjudication([sideBlank, sideBlank])).toBe(true)
   expect(sheetRequiresAdjudication([sideBlank, sideNotBlank])).toBe(false)

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -207,7 +207,6 @@ export async function getBallotImageData(
 /**
  * Determine if a sheet needs adjudication.
  */
-
 export function sheetRequiresAdjudication([front, back]: SheetOf<
   PageInterpretation
 >): boolean {


### PR DESCRIPTION
Type annotations allow TS & the language server to provide IntelliSense suggestions in supported editors for the properties and their types. If you leave them off of a variable declaration where you're building up an object expression manually, TS cannot really help you. Likewise, [casting may allow you to create an object that is "close enough" to correct but not actually conform to the type][1], whereas a [type annotation will force you to correctly build the object][2].

[1]: https://www.typescriptlang.org/play?#code/JYOwLgpgTgZghgYwgAgILIN4Chm+XALmRAFcBbAI2hzwqIGcwpQBzLAXyywQHsRHkPZAF5M+IgGZk7fPTTc+9HgBsIAOmU8WACjABPAA4QeMQWooBKIA
[2]: https://www.typescriptlang.org/play?#code/JYOwLgpgTgZghgYwgAgILIN4Chm+XALmRAFcBbAI2hzwqIGcwpQBzLAXyywQHsRHkPIugC8mfEQDMyTr348ANhAB0CniwAUYAJ4AHCDxiDlFAJRA