### PR TITLE
fix: ensure switching between test/live mode works

### DIFF
--- a/src/importer.ts
+++ b/src/importer.ts
@@ -160,7 +160,8 @@ export default class SystemImporter implements Importer {
   public async setTestMode(testMode: boolean): Promise<void> {
     debug('setting test mode to %s', testMode)
     await this.doZero()
-    this.interpreter.setTestMode(testMode)
+    await this.store.setTestMode(testMode)
+    await this.restoreConfig()
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -104,7 +104,6 @@ export function buildApp({ store, importer }: AppOptions): Application {
               throw new TypeError()
             }
             await importer.setTestMode(value)
-            await store.setTestMode(value)
             break
           }
         }


### PR DESCRIPTION
The underlying interpreter is taught how to read the templates either when a new ballot package is uploaded or on startup when loading template information from the database. When switching test/live mode, the interpreter was recreated but _without teaching it about the templates_. Therefore, no matter what it was given, it would always throw "Cannot scan ballot because not all required templates have been added". That is, every `interpretBallot` call would fail.

To fix this issue, this commit restores the config from the database after switching test mode. Because this takes a non-trivial amount of time, we need to update bsd to tell the user what's happening.

Closes votingworks/vxmail#230