### PR TITLE
fix: clear current election from memory on change

### DIFF
--- a/src/importer.ts
+++ b/src/importer.ts
@@ -503,5 +503,6 @@ export default class SystemImporter implements Importer {
   public async unconfigure(): Promise<void> {
     await this.doZero()
     await this.store.reset() // destroy all data
+    this.interpreter.electionDidChange()
   }
 }

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -115,6 +115,7 @@ export interface Interpreter {
     interpretFileParams: InterpretFileParams
   ): Promise<InterpretFileResult>
   setTestMode(testMode: boolean): void
+  electionDidChange(): void
 }
 
 interface BallotImageData {
@@ -401,6 +402,10 @@ export default class SummaryBallotInterpreter implements Interpreter {
 
   public setTestMode(testMode: boolean): void {
     this.testMode = testMode
+    this.hmpbInterpreter = undefined
+  }
+
+  public electionDidChange(): void {
     this.hmpbInterpreter = undefined
   }
 

--- a/test/fixtures/choctaw-2020-09-22-02f807b005/fixtures.ts
+++ b/test/fixtures/choctaw-2020-09-22-02f807b005/fixtures.ts
@@ -1,5 +1,7 @@
 import { join } from 'path'
+import election from './election'
 
+export { election }
 export const ballotPdf = join(__dirname, 'ballot.pdf')
 export const ballot6522Pdf = join(__dirname, 'ballot-6522.pdf')
 export const blankPage1 = join(__dirname, 'blank-p1.png')

--- a/test/util/mocks.ts
+++ b/test/util/mocks.ts
@@ -11,6 +11,7 @@ export function makeMockInterpreter(): jest.Mocked<Interpreter> {
     addHmpbTemplate: jest.fn(),
     interpretFile: jest.fn(),
     setTestMode: jest.fn(),
+    electionDidChange: jest.fn(),
   }
 }
 


### PR DESCRIPTION
This fixes an issue where changing an election would cause all future scans to fail until the process was restarted.