### PR TITLE
clip a larger portion of the image

### DIFF
--- a/src/endToEndHmpb.test.ts
+++ b/src/endToEndHmpb.test.ts
@@ -61,7 +61,7 @@ afterEach(async () => {
 })
 
 test('going through the whole process works', async () => {
-  jest.setTimeout(20000)
+  jest.setTimeout(25000)
 
   const { election } = stateOfHamilton
   await importer.restoreConfig()
@@ -181,7 +181,7 @@ test('going through the whole process works', async () => {
 })
 
 test('failed scan with QR code can be adjudicated and exported', async () => {
-  jest.setTimeout(20000)
+  jest.setTimeout(25000)
 
   const { election } = stateOfHamilton
   await importer.restoreConfig()
@@ -309,7 +309,7 @@ test('failed scan with QR code can be adjudicated and exported', async () => {
 })
 
 test('ms-either-neither end-to-end', async () => {
-  jest.setTimeout(20000)
+  jest.setTimeout(25000)
 
   const {
     election,

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -171,7 +171,7 @@ const detectQRCode = async (
   imageData: ImageData
 ): Promise<{ data: Buffer; position: 'top' | 'bottom' } | undefined> => {
   const { data, width, height } = imageData
-  const clipHeight = Math.floor(height / 4)
+  const clipHeight = Math.floor(height / 2.5)
   const img = sharp(Buffer.from(data), {
     raw: {
       channels: (data.length / width / height) as Channels,


### PR DESCRIPTION
This enables scanning letter size in legal mode for BMD ballots, without changing the logic that determines paper orientation.