### PR TITLE
scan at 200dpi

### DIFF
--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -62,7 +62,7 @@ export class FujitsuScanner implements Scanner {
       '-d',
       'fujitsu',
       '--resolution',
-      '300',
+      '200',
       `--format=${this.format}`,
       '--source=ADF Duplex',
       '--dropoutcolor',


### PR DESCRIPTION
Smaller images are processed much faster, and 200dpi doesn't appear to reduce our ability to find QR codes.