### PR TITLE
on error in importing, properly clean up the scanning process.

### DIFF
--- a/src/importer.ts
+++ b/src/importer.ts
@@ -348,9 +348,15 @@ export default class SystemImporter implements Importer {
   private async finishBatch(error?: string): Promise<void> {
     if (this.batchId) {
       await this.store.finishBatch({ batchId: this.batchId, error })
+      this.batchId = undefined
     }
-    this.sheetGenerator = undefined
-    this.batchId = undefined
+
+    if (this.sheetGenerator) {
+      if (error) {
+        await this.sheetGenerator.throw(new Error(error))
+      }
+      this.sheetGenerator = undefined
+    }
   }
 
   /**


### PR DESCRIPTION
This mostly (but not completely) solves the problem if starting the scanning process before the configuration has been loaded by the worker processes. The error is now handled.