### PR TITLE
fix adjudication for either-neither contests.

### DIFF
--- a/src/util/optionMarkStatus.test.ts
+++ b/src/util/optionMarkStatus.test.ts
@@ -1,0 +1,137 @@
+import {
+  MarkThresholds,
+  YesNoContest,
+  CandidateContest,
+  MsEitherNeitherContest,
+} from '@votingworks/ballot-encoder'
+
+import { MarkStatus } from '../types/ballot-review'
+
+import optionMarkStatus from './optionMarkStatus'
+
+import election from '../../test/fixtures/state-of-hamilton/election'
+import eitherNeitherElection from '../../test/fixtures/choctaw-mock-general-election-2020/election'
+
+const markThresholds: MarkThresholds = { definite: 0.17, marginal: 0.17 }
+const defaultShape = {
+  bounds: { x: 0, y: 0, width: 10, height: 10 },
+  inner: { x: 0, y: 0, width: 10, height: 10 },
+}
+
+test('a yesno mark', () => {
+  const contest = election.contests.find(
+    (c) => c.type === 'yesno'
+  ) as YesNoContest
+  const result = optionMarkStatus({
+    markThresholds,
+    marks: [
+      {
+        type: 'yesno',
+        bounds: defaultShape.bounds,
+        contest,
+        target: defaultShape,
+        option: 'yes',
+        score: 0.5,
+        scoredOffset: { x: 1, y: 1 },
+      },
+    ],
+    contestId: contest.id,
+    optionId: 'yes',
+  })
+
+  expect(result).toBe(MarkStatus.Marked)
+
+  const emptyResult = optionMarkStatus({
+    markThresholds,
+    marks: [],
+    contestId: contest.id,
+    optionId: 'yes',
+  })
+
+  expect(emptyResult).toBe(MarkStatus.Unmarked)
+})
+
+test('a candidate mark', () => {
+  const contest = election.contests.find(
+    (c) => c.type === 'candidate'
+  ) as CandidateContest
+  const result = optionMarkStatus({
+    markThresholds,
+    marks: [
+      {
+        type: 'candidate',
+        bounds: defaultShape.bounds,
+        contest,
+        target: defaultShape,
+        option: contest.candidates[2],
+        score: 0.5,
+        scoredOffset: { x: 1, y: 1 },
+      },
+    ],
+    contestId: contest.id,
+    optionId: contest.candidates[2].id,
+  })
+
+  expect(result).toBe(MarkStatus.Marked)
+
+  const emptyResult = optionMarkStatus({
+    markThresholds,
+    marks: [],
+    contestId: contest.id,
+    optionId: contest.candidates[2].id,
+  })
+
+  expect(emptyResult).toBe(MarkStatus.Unmarked)
+})
+
+test('a ms-either-neither mark', () => {
+  const contest = eitherNeitherElection.contests.find(
+    (c) => c.type === 'ms-either-neither'
+  ) as MsEitherNeitherContest
+  const eitherResult = optionMarkStatus({
+    markThresholds,
+    marks: [
+      {
+        type: 'ms-either-neither',
+        bounds: defaultShape.bounds,
+        contest,
+        target: defaultShape,
+        option: contest.neitherOption,
+        score: 0.5,
+        scoredOffset: { x: 1, y: 1 },
+      },
+    ],
+    contestId: contest.eitherNeitherContestId,
+    optionId: 'no',
+  })
+
+  expect(eitherResult).toBe(MarkStatus.Marked)
+
+  const pickOneResult = optionMarkStatus({
+    markThresholds,
+    marks: [
+      {
+        type: 'ms-either-neither',
+        bounds: defaultShape.bounds,
+        contest,
+        target: defaultShape,
+        option: contest.firstOption,
+        score: 0.5,
+        scoredOffset: { x: 1, y: 1 },
+      },
+    ],
+    contestId: contest.pickOneContestId,
+    optionId: 'yes',
+  })
+
+  expect(pickOneResult).toBe(MarkStatus.Marked)
+
+  const emptyResult = optionMarkStatus({
+    markThresholds,
+    marks: [],
+    contestId: contest.id,
+    optionId: 'yes',
+  })
+
+  expect(emptyResult).toBe(MarkStatus.Unmarked)
+})

--- a/src/util/optionMarkStatus.ts
+++ b/src/util/optionMarkStatus.ts
@@ -1,0 +1,75 @@
+import { Contest, MarkThresholds } from '@votingworks/ballot-encoder'
+import { BallotMark } from '@votingworks/hmpb-interpreter'
+import { ContestOption, MarkStatus, getMarkStatus } from '../types'
+
+/**
+ * state of the mark for a given contest and option
+ */
+export default function optionMarkStatus({
+  markThresholds,
+  marks,
+  contestId,
+  optionId,
+}: {
+  markThresholds: MarkThresholds
+  marks: BallotMark[]
+  contestId: Contest['id']
+  optionId: ContestOption['id']
+}): MarkStatus {
+  for (const mark of marks) {
+    if (
+      mark.type === 'stray' ||
+      (mark.type !== 'ms-either-neither' && mark.contest.id !== contestId)
+    ) {
+      continue
+    }
+
+    // the criteria for ms-either-neither is more complex, handling it in the switch.
+
+    switch (mark.type) {
+      case 'ms-either-neither':
+        if (mark.contest.eitherNeitherContestId === contestId) {
+          if (
+            (mark.contest.eitherOption.id === mark.option.id &&
+              optionId === 'yes') ||
+            (mark.contest.neitherOption.id === mark.option.id &&
+              optionId === 'no')
+          ) {
+            return getMarkStatus(mark, markThresholds)
+          }
+        }
+
+        if (mark.contest.pickOneContestId === contestId) {
+          if (
+            (mark.contest.firstOption.id === mark.option.id &&
+              optionId === 'yes') ||
+            (mark.contest.secondOption.id === mark.option.id &&
+              optionId === 'no')
+          ) {
+            return getMarkStatus(mark, markThresholds)
+          }
+        }
+
+        break
+      case 'candidate':
+        if (mark.option.id === optionId) {
+          return getMarkStatus(mark, markThresholds)
+        }
+        break
+
+      case 'yesno':
+        if (mark.option === optionId) {
+          return getMarkStatus(mark, markThresholds)
+        }
+        break
+
+      default:
+        throw new Error(
+          // @ts-expect-error - `mark` is of type `never` since we exhausted all branches, in theory
+          `contest type is not yet supported: ${mark.type}`
+        )
+    }
+  }
+
+  return MarkStatus.Unmarked
+}


### PR DESCRIPTION
This wasn't working before because of the mismatch between inner and outer contest IDs.

This may hint at a larger refactor for either-neither in the future. For now, making a change that is minimal and contained.