### PR TITLE
fix(perf): make QR code detection faster

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
     SharedArrayBuffer: 'readonly',
     // fetch: true, // required if using via 'jest-fetch-mock'
     fetchMock: true, // required if using via 'jest-fetch-mock'
+    BigInt: true,
   },
   parserOptions: {
     ecmaFeatures: {

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -30,6 +30,7 @@ import ballotAdjudicationReasons, {
   adjudicationReasonDescription,
 } from './util/ballotAdjudicationReasons'
 import optionMarkStatus from './util/optionMarkStatus'
+import { time } from './util/perf'
 import { detectQRCode } from './util/qrcode'
 import threshold from './util/threshold'
 
@@ -259,9 +260,11 @@ export default class SummaryBallotInterpreter implements Interpreter {
     ballotImagePath,
     ballotImageFile,
   }: InterpretFileParams): Promise<InterpretFileResult> {
+    const timer = time(`interpretFile: ${ballotImagePath}`)
     const result = await getBallotImageData(ballotImageFile, ballotImagePath)
 
     if (isErrorResult(result)) {
+      timer.end()
       return { interpretation: result.error }
     }
 
@@ -272,8 +275,10 @@ export default class SummaryBallotInterpreter implements Interpreter {
       const bmdMetadata = (bmdResult.interpretation as InterpretedBmdPage)
         .metadata
       if (bmdMetadata.isTestMode === this.testMode) {
+        timer.end()
         return bmdResult
       } else {
+        timer.end()
         return {
           interpretation: {
             type: 'InvalidTestModePage',
@@ -287,6 +292,7 @@ export default class SummaryBallotInterpreter implements Interpreter {
       const hmpbResult = await this.interpretHMPBFile(ballotImageData)
 
       if (hmpbResult) {
+        timer.end()
         return hmpbResult
       }
     } catch (error) {
@@ -306,6 +312,7 @@ export default class SummaryBallotInterpreter implements Interpreter {
           metadata.isTestMode,
           this.testMode
         )
+        timer.end()
         return {
           interpretation: {
             type: 'InvalidTestModePage',
@@ -314,6 +321,7 @@ export default class SummaryBallotInterpreter implements Interpreter {
         }
       }
 
+      timer.end()
       return {
         interpretation: {
           type: 'UninterpretedHmpbPage',
@@ -321,6 +329,7 @@ export default class SummaryBallotInterpreter implements Interpreter {
         },
       }
     } catch (error) {
+      timer.end()
       return {
         interpretation: {
           type: 'UnreadablePage',

--- a/src/util/perf.test.ts
+++ b/src/util/perf.test.ts
@@ -1,0 +1,35 @@
+import { formatDurationNs, time } from './perf'
+
+test('formatDurationNs as nanoseconds', () => {
+  expect(formatDurationNs(BigInt(0))).toEqual('0ns')
+  expect(formatDurationNs(BigInt(1))).toEqual('1ns')
+  expect(formatDurationNs(BigInt(999))).toEqual('999ns')
+})
+
+test('formatDurationNs as microseconds', () => {
+  expect(formatDurationNs(BigInt(1000))).toEqual('1µs')
+  expect(formatDurationNs(BigInt(1100))).toEqual('1.1µs')
+  expect(formatDurationNs(BigInt(9999))).toEqual('9.99µs')
+  expect(formatDurationNs(BigInt(123_456))).toEqual('123.45µs')
+})
+
+test('formatDuationNs as milliseconds', () => {
+  expect(formatDurationNs(BigInt(1_234_567))).toEqual('1.23ms')
+  expect(formatDurationNs(BigInt(987_654_321))).toEqual('987.65ms')
+})
+
+test('formatDuationNs as seconds', () => {
+  expect(formatDurationNs(BigInt(1_234_567_000))).toEqual('1.23s')
+})
+
+test('time gets and logs duration in nanoseconds', () => {
+  const t = time('counting')
+
+  let c = 0
+  for (let i = 0; i < 10_000; i++) {
+    c++
+  }
+
+  expect(c).toEqual(10_000)
+  expect(typeof t.end()).toEqual('bigint')
+})

--- a/src/util/perf.ts
+++ b/src/util/perf.ts
@@ -1,0 +1,33 @@
+import makeDebug from 'debug'
+
+const debug = makeDebug('module-scan:perf')
+
+export function formatDurationNs(nanoseconds: bigint): string {
+  if (nanoseconds < 1000) {
+    return `${nanoseconds}ns`
+  } else if (nanoseconds < 1_000_000) {
+    return `${Number(nanoseconds / BigInt(10)) / 100}µs`
+  } else if (nanoseconds < 1_000_000_000) {
+    return `${Number(nanoseconds / BigInt(10_000)) / 100}ms`
+  } else {
+    return `${Number(nanoseconds / BigInt(10_000_000)) / 100}s`
+  }
+}
+
+export interface Timer {
+  end(): BigInt
+}
+
+export function time(label: string): Timer {
+  debug('%s START', label)
+  const start = process.hrtime.bigint()
+
+  return {
+    end(): BigInt {
+      const end = process.hrtime.bigint()
+      const duration = end - start
+      debug('%s END (took %s)', label, formatDurationNs(duration))
+      return duration
+    },
+  }
+}


### PR DESCRIPTION
zbarimg (via qrdetect) and quirc (via node-quirc) are both fairly fast QR code readers, but calling into node-quirc requires passing either JPEG or PNG data. We can and should fix that in the future, but for now it means a fairly heavy penalty (O(100ms)) for its use. So now we check both the top and bottom using qrdetect first (O(10ms)), and fall back to node-quirc if we can't find the QR code.

Additionally, we can save a little bit of time by checking the most likely half first. We hypothesize that EOs will put the paper in so that it looks right-side up to them, which means upside-down for the scanner. So we check the "top" first to find a QR code in the bottom of an upside-down HMPB image.

Both of these changes even out the time it takes with either orientation to be about the same, ~700-900ms on my machine per sheet.