### PR TITLE
feat: add restore script

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ front-02.png
 back-02.png
 EOS
 MOCK_SCANNER_FILES=@manifest yarn start
+
+# scanning from an election backup file
+./bin/restore-backup /path/to/election-backup.zip
+MOCK_SCANNER_FILES=@/path/to/election-backup/manifest yarn start
 ```
 
 ## API Documentation

--- a/bin/restore-backup
+++ b/bin/restore-backup
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# e.g. election-a0eb9bf590-2020-09-23T01-41-38-773Z-backup.zip
+BACKUP_FILE="${1:-}"
+
+if [ -z "${BACKUP_FILE}" ]; then
+  echo "usage: restore-backup BACKUP_FILE.zip" >&2
+  exit 1
+fi
+
+BACKUP_DIR=$(realpath "${BACKUP_FILE%.*}")
+mkdir -p "${BACKUP_DIR}"
+
+MANIFEST_FILE="${BACKUP_DIR}/manifest"
+zipinfo -1 "${BACKUP_FILE}" | grep -- "-original.png" | sort > "${MANIFEST_FILE}"
+
+echo -e "\e[1mExtracting images…\e[0m"
+unzip -o "${BACKUP_FILE}" "*.png" -d "${BACKUP_DIR}"
+
+echo
+echo -e "\e[1mExtracting database…\e[0m"
+unzip -o "${BACKUP_FILE}" ballots.db
+sqlite3 ballots.db "update sheets set front_original_filename = '${BACKUP_DIR}/' || front_original_filename, front_normalized_filename = '${BACKUP_DIR}/' || front_normalized_filename, back_original_filename = '${BACKUP_DIR}/' || back_original_filename, back_normalized_filename = '${BACKUP_DIR}/' || back_normalized_filename;"
+shasum -a 256 schema.sql | cut -d " " -f 1 > ballots.db.digest
+
+echo
+echo -e "\e[1mSuccess! Your backup has been restored.\e[0m"
+echo -e "Restart module-scan/bsd to see the changes."
+echo
+echo -e "To scan using the restored images, run this then restart module-scan/bsd in the same terminal:"
+echo -e "$ \e[4mexport MOCK_SCANNER_FILES=@${MANIFEST_FILE}\e[0m"

--- a/src/store.ts
+++ b/src/store.ts
@@ -97,7 +97,7 @@ export default class Store {
     const schemaDigestPath = `${dbPath}.digest`
     let schemaDigest: string | undefined
     try {
-      schemaDigest = await fs.readFile(schemaDigestPath, 'utf-8')
+      schemaDigest = (await fs.readFile(schemaDigestPath, 'utf-8')).trim()
     } catch {
       debug(
         'could not read %s, assuming the database needs to be created',
@@ -109,7 +109,11 @@ export default class Store {
     const shouldResetDatabase = newSchemaDigest !== schemaDigest
 
     if (shouldResetDatabase) {
-      debug('database schema has changed')
+      debug(
+        'database schema has changed (%s ≉ %s)',
+        schemaDigest,
+        newSchemaDigest
+      )
       try {
         const backupPath = `${dbPath}.backup-${new Date()
           .toISOString()


### PR DESCRIPTION
This script can be used to restore an election backup file for local viewing or rescanning.

Example output:

```
Extracting database…
Archive:  /home/brian/Desktop/choctaw-10132020-special-runoff-backup.zip
  inflating: ballots.db              

Success! Your backup has been restored.
Restart module-scan/bsd to see the changes.

To scan using the restored images, run this then restart module-scan/bsd in the same terminal:
$ export MOCK_SCANNER_FILES=@/home/brian/Desktop/choctaw-10132020-special-runoff-backup/manifest
```