### PR TITLE
fix: prevent sharp-related memory leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     ]
   },
   "dependencies": {
-    "@types/sharp": "^0.26.0",
     "@votingworks/ballot-encoder": "^4.0.0",
     "@votingworks/hmpb-interpreter": "^5.2.12",
     "@votingworks/qrdetect": "^1.0.1",
@@ -46,7 +45,6 @@
     "node-quirc": "^2.2.1",
     "pdfjs-dist": "^2.3.200",
     "rimraf": "^3.0.2",
-    "sharp": "^0.26.1",
     "sqlite3": "^4.0.8",
     "tmp": "^0.2.1",
     "uuid": "^8.3.0",
@@ -83,7 +81,6 @@
     "husky": "^4.2.5",
     "jest": "^26.0.1",
     "lint-staged": "^10.2.6",
-    "pngjs": "^5.0.0",
     "prettier": "^2.0.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/cli/render-pages.test.ts
+++ b/src/cli/render-pages.test.ts
@@ -2,10 +2,10 @@ import main from './render-pages'
 import { WritableStream } from 'memory-streams'
 import { ballotPdf } from '../../test/fixtures/choctaw-2020-09-22-f30480cc99'
 import { promises as fs } from 'fs'
-import sharp from 'sharp'
 import { join } from 'path'
 import { pathExists } from 'fs-extra'
 import { tmpNameSync } from 'tmp'
+import { loadImageData } from '../util/images'
 
 function fakeOutput(): WritableStream & NodeJS.WriteStream {
   return new WritableStream() as WritableStream & NodeJS.WriteStream
@@ -54,17 +54,12 @@ test('generates one PNG image per PDF page', async () => {
     stderr: '',
   })
 
-  expect(await sharp(join(tmpDir, 'ballot-p1.png')).metadata()).toEqual(
-    expect.objectContaining({
+  for (const filename of ['ballot-p1.png', 'ballot-p2.png']) {
+    const { width, height } = await loadImageData(join(tmpDir, filename))
+    expect({ width, height }).toEqual({
       width: 1224,
       height: 1584,
     })
-  )
-  expect(await sharp(join(tmpDir, 'ballot-p2.png')).metadata()).toEqual(
-    expect.objectContaining({
-      width: 1224,
-      height: 1584,
-    })
-  )
+  }
   expect(await pathExists(join(tmpDir, 'ballot-p3.png'))).toBe(false)
 })

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -5,7 +5,6 @@ import * as fsExtra from 'fs-extra'
 import * as streams from 'memory-streams'
 import { join } from 'path'
 import { sync as rimraf } from 'rimraf'
-import sharp, { Raw } from 'sharp'
 import { v4 as uuid } from 'uuid'
 import { PageInterpretation } from './interpreter'
 import { Scanner } from './scanner'
@@ -17,6 +16,7 @@ import {
   SheetOf,
   Side,
 } from './types'
+import { toPNG } from './util/images'
 import pdfToImages from './util/pdfToImages'
 import { call, Input, InterpretOutput, Output } from './workers/interpret'
 import { inlinePool, WorkerPool } from './workers/pool'
@@ -72,20 +72,7 @@ export async function saveImages(
 
   if (normalizedImage) {
     debug('about to write normalized ballot image to %s', normalizedImagePath)
-    await fsExtra.writeFile(
-      normalizedImagePath,
-      await sharp(Buffer.from(normalizedImage.data.buffer), {
-        raw: {
-          width: normalizedImage.width,
-          height: normalizedImage.height,
-          channels: (normalizedImage.data.length /
-            (normalizedImage.width *
-              normalizedImage.height)) as Raw['channels'],
-        },
-      })
-        .png()
-        .toBuffer()
-    )
+    await fsExtra.writeFile(normalizedImagePath, await toPNG(normalizedImage))
     debug('wrote normalized ballot image to %s', normalizedImagePath)
     return { original: originalImagePath, normalized: normalizedImagePath }
   }

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -23,12 +23,12 @@ import {
   Size,
 } from '@votingworks/hmpb-interpreter'
 import makeDebug from 'debug'
-import sharp from 'sharp'
 import { BallotMetadata, isErrorResult, Result, SheetOf } from './types'
 import { AdjudicationInfo } from './types/ballot-review'
 import ballotAdjudicationReasons, {
   adjudicationReasonDescription,
 } from './util/ballotAdjudicationReasons'
+import { loadImageData } from './util/images'
 import optionMarkStatus from './util/optionMarkStatus'
 import { time } from './util/perf'
 import { detectQRCode } from './util/qrcode'
@@ -117,12 +117,7 @@ export async function getBallotImageData(
   file: Buffer,
   filename: string
 ): Promise<Result<PageInterpretation, BallotImageData>> {
-  const img = sharp(file).raw().ensureAlpha()
-  const {
-    data,
-    info: { width, height },
-  } = await img.toBuffer({ resolveWithObject: true })
-
+  const { data, width, height } = await loadImageData(file)
   const imageThreshold = threshold(data)
   if (
     imageThreshold.foreground.ratio < MAXIMUM_BLANK_PAGE_FOREGROUND_PIXEL_RATIO

--- a/src/store.ts
+++ b/src/store.ts
@@ -18,9 +18,9 @@ import { createHash } from 'crypto'
 import makeDebug from 'debug'
 import { promises as fs } from 'fs'
 import { join } from 'path'
-import sharp from 'sharp'
 import * as sqlite3 from 'sqlite3'
 import { Writable } from 'stream'
+import { inspect } from 'util'
 import { v4 as uuid } from 'uuid'
 import { buildCastVoteRecord } from './buildCastVoteRecord'
 import {
@@ -32,13 +32,13 @@ import {
   AdjudicationStatus,
   BallotMetadata,
   BatchInfo,
+  ElectionDefinition,
   getMarkStatus,
   isMarginalMark,
   PageInterpretationWithFiles,
   SerializableBallotPageLayout,
   SheetOf,
   Side,
-  ElectionDefinition,
 } from './types'
 import {
   AdjudicationInfo,
@@ -47,11 +47,11 @@ import {
   MarksByContestId,
   ReviewBallot,
 } from './types/ballot-review'
-import { BallotSheetInfo } from './util/ballotAdjudicationReasons'
 import allContestOptions from './util/allContestOptions'
+import { BallotSheetInfo } from './util/ballotAdjudicationReasons'
 import getBallotPageContests from './util/getBallotPageContests'
+import { loadImageData } from './util/images'
 import { changesFromMarks, mergeChanges } from './util/marks'
-import { inspect } from 'util'
 
 const debug = makeDebug('module-scan:store')
 
@@ -614,7 +614,7 @@ export default class Store {
         return marks.ballotSize
       }
 
-      const { width, height } = await sharp(row.normalizedFilename).metadata()
+      const { width, height } = await loadImageData(row.normalizedFilename)
 
       if (!width || !height) {
         throw new Error(

--- a/src/util/images.ts
+++ b/src/util/images.ts
@@ -1,0 +1,24 @@
+import { createCanvas, createImageData, loadImage } from 'canvas'
+
+function ensureImageData(imageData: ImageData): ImageData {
+  return createImageData(imageData.data, imageData.width, imageData.height)
+}
+
+export async function loadImageData(path: string): Promise<ImageData>
+export async function loadImageData(data: Buffer): Promise<ImageData>
+export async function loadImageData(
+  pathOrData: string | Buffer
+): Promise<ImageData> {
+  const img = await loadImage(pathOrData)
+  const canvas = createCanvas(img.width, img.height)
+  const context = canvas.getContext('2d')
+  context.drawImage(img, 0, 0)
+  return context.getImageData(0, 0, img.width, img.height)
+}
+
+export async function toPNG(imageData: ImageData): Promise<Buffer> {
+  const canvas = createCanvas(imageData.width, imageData.height)
+  const context = canvas.getContext('2d')
+  context.putImageData(ensureImageData(imageData), 0, 0)
+  return canvas.toBuffer()
+}

--- a/src/util/qrcode.ts
+++ b/src/util/qrcode.ts
@@ -4,7 +4,7 @@ import crop from '@votingworks/hmpb-interpreter/dist/src/utils/crop'
 import { detect as qrdetect } from '@votingworks/qrdetect'
 import makeDebug from 'debug'
 import { decode as quircDecode } from 'node-quirc'
-import sharp, { Channels } from 'sharp'
+import { toPNG } from './images'
 import { time } from './perf'
 
 const debug = makeDebug('module-scan:qrcode')
@@ -118,18 +118,7 @@ export const detectQRCode = async (
       const cropped = crop(imageData, bounds)
 
       debug('generating PNG for quirc')
-      const { data, width, height } = cropped
-      const img = await sharp(Buffer.from(data), {
-        raw: {
-          channels: (data.length / width / height) as Channels,
-          width,
-          height,
-        },
-      })
-        .raw()
-        .ensureAlpha()
-        .png()
-        .toBuffer()
+      const img = await toPNG(cropped)
 
       debug('scanning with quirc')
       const results = (await quircDecode(img))[0]

--- a/test/util/mocks.ts
+++ b/test/util/mocks.ts
@@ -1,11 +1,12 @@
 import { ChildProcess } from 'child_process'
 import { EventEmitter } from 'events'
-import sharp from 'sharp'
+import { writeFile } from 'fs-extra'
 import { Readable, Writable } from 'stream'
 import { fileSync } from 'tmp'
 import { Importer } from '../../src/importer'
 import { Scanner } from '../../src/scanner'
 import { SheetOf } from '../../src/types'
+import { toPNG } from '../../src/util/images'
 import { inlinePool, WorkerOps, WorkerPool } from '../../src/workers/pool'
 
 export function mockWorkerPoolProvider<I, O>(
@@ -269,10 +270,9 @@ export function makeMockChildProcess(): MockChildProcess {
 
 export async function makeImageFile(): Promise<string> {
   const imageFile = fileSync()
-  await sharp({
-    create: { width: 1, height: 1, channels: 3, background: '#000' },
-  })
-    .png()
-    .toFile(imageFile.name)
+  await writeFile(
+    imageFile.name,
+    await toPNG({ data: Uint8ClampedArray.of(0, 0, 0), width: 1, height: 1 })
+  )
   return imageFile.name
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -909,13 +909,6 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@types/sharp@^0.26.0":
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/@types/sharp/-/sharp-0.26.0.tgz#2fa8419dbdaca8dd38f73888b27b207f188a8669"
-  integrity sha512-oJrR8eiwpL7qykn2IeFRduXM4za7z+7yOUEbKVtuDQ/F6htDLHYO6IbzhaJQHV5n6O3adIh4tJvtgPyLyyydqg==
-  dependencies:
-    "@types/node" "*"
-
 "@types/sqlite3@^3.1.6":
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/@types/sqlite3/-/sqlite3-3.1.6.tgz#554ce76f886eb187cfc86e2f0bb67cbac4f568ce"
@@ -5060,11 +5053,6 @@ please-upgrade-node@^3.2.0:
   integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
   dependencies:
     semver-compare "^1.0.0"
-
-pngjs@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-5.0.0.tgz#e79dd2b215767fd9c04561c01236df960bce7fbb"
-  integrity sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==
 
 posix-character-classes@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
Probably this: https://github.com/lovell/sharp/issues/1803. Tried pngjs (not compatible enough), jimp (too slow), and finally back to canvas which we've used before. It is a native dependency but doesn't seem to have the particular pathological behavior that sharp does while loading blank pages repeatedly.