### PR TITLE
fix: restore `tmp/.gitkeep` on factory reset

### DIFF
--- a/src/importer.ts
+++ b/src/importer.ts
@@ -507,5 +507,9 @@ export default class SystemImporter implements Importer {
     fsExtra.mkdirpSync(tmpdir)
     fsExtra.mkdirpSync(this.scannedImagesPath)
     fsExtra.mkdirpSync(this.importedImagesPath)
+
+    // and restore the .gitkeep file, or suffer the wrath of a dirty git status
+    // in development
+    await fsExtra.writeFile(join(tmpdir, '.gitkeep'), '\n')
   }
 }


### PR DESCRIPTION
Otherwise local development becomes a game of whack-a-mole with that file.