### PR TITLE
refactor: remove unused `invalidateBatch` endpoint

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -201,13 +201,6 @@ test('POST /scan/scanFiles', async () => {
     .expect(200, { status: 'ok' })
 })
 
-test('POST /scan/invalidateBatch', async () => {
-  await request(app)
-    .post('/scan/invalidateBatch')
-    .set('Accept', 'application/json')
-    .expect(200, { status: 'ok' })
-})
-
 test('POST /scan/export', async () => {
   importerMock.doExport.mockResolvedValue('')
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -227,10 +227,6 @@ export function buildApp({ store, importer }: AppOptions): Application {
     })
   }
 
-  app.post('/scan/invalidateBatch', (_request, response) => {
-    response.json({ status: 'ok' })
-  })
-
   app.post(
     '/scan/hmpb/addTemplates',
     upload.fields([


### PR DESCRIPTION
As far as I can tell, this endpoint has never been used: https://github.com/votingworks/module-scan/commit/b4d12c3920a6421f3098d8fc7cd7d92934d0f245